### PR TITLE
[fix] : apply const values

### DIFF
--- a/src/main/java/kr/where/backend/api/IntraApiService.java
+++ b/src/main/java/kr/where/backend/api/IntraApiService.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class IntraApiService {
 
+    private static final String END_DELIMITER = "z";
+
     /**
      * 본인 정보 반환
      */
@@ -82,13 +84,14 @@ public class IntraApiService {
     }
 
     /**
-     * begin 부터 end 까지 intra id를 가진 카뎃 10명의 정보 반환
+     * keyWord 부터 end 까지 intra id를 가진 카뎃 10명의 정보 반환
      */
     @Retryable
-    public List<Seoul42> get42UsersInfoInRange(final String token, final String begin, final String end) {
+    public List<Seoul42> get42UsersInfoInRange(final String token, final String keyWord) {
         return JsonMapper
                 .mappings(HttpResponse.getMethod(
-                                HttpHeader.request42Info(token), UriBuilder.searchCadets(begin, end)),
+                                HttpHeader.request42Info(token),
+                                UriBuilder.searchCadets(keyWord, keyWord + END_DELIMITER)),
                         Seoul42[].class);
     }
 


### PR DESCRIPTION
- 검색에 사용하는 api servie에 상수 추가
- 검색하는 range 쿼리 옵션이 알파벳의 마지막 'z'를 넣어야지 검색해주기때문에, end 키워드를 받지 않고 바로 + z 해서 검색