### PR TITLE
기능 추가 및 반환 스키마 통일

### DIFF
--- a/src/main/java/kr/where/backend/group/GroupController.java
+++ b/src/main/java/kr/where/backend/group/GroupController.java
@@ -140,7 +140,7 @@ public class GroupController {
     )
     @PostMapping("/groupmember")
     public ResponseEntity createGroupMember(@RequestBody CreateGroupMemberDTO createGroupMemberDTO) {
-        final ResponseGroupMemberDTO dto = groupMemberService.createGroupMember(createGroupMemberDTO);
+        final ResponseGroupMemberDTO dto = groupMemberService.createGroupMember(createGroupMemberDTO, false);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }
@@ -159,8 +159,8 @@ public class GroupController {
             }
     )
     @PostMapping("/groupmember/not-ingroup")
-    public ResponseEntity<List<ResponseGroupMemberDTO>> findMemberListNotInGroup(@RequestParam("default groupId") Long default_groupID, @RequestParam("groupId") Long groupId) {
-        final List<ResponseGroupMemberDTO> groupMemberDTOS = groupMemberService.findMemberNotInGroup(default_groupID, groupId);
+    public ResponseEntity<List<ResponseOneGroupMemberDTO>> findMemberListNotInGroup(@RequestParam("default groupId") Long default_groupID, @RequestParam("groupId") Long groupId) {
+        final List<ResponseOneGroupMemberDTO> groupMemberDTOS = groupMemberService.findMemberNotInGroup(default_groupID, groupId);
 
         return ResponseEntity.status(HttpStatus.OK).body(groupMemberDTOS);
     }
@@ -198,7 +198,7 @@ public class GroupController {
     )
     @GetMapping("/groupmember")
     public ResponseEntity findAllGroupFriends(@RequestParam("groupId") Long groupId) {
-        final List<ResponseGroupMemberDTO> dto = groupMemberService.findGroupMemberbyGroupId(groupId);
+        final List<ResponseOneGroupMemberDTO> dto = groupMemberService.findGroupMemberbyGroupId(groupId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(dto);
     }

--- a/src/main/java/kr/where/backend/group/GroupMemberRepository.java
+++ b/src/main/java/kr/where/backend/group/GroupMemberRepository.java
@@ -16,7 +16,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     List<GroupMember> findGroupMembersByMemberAndIsOwner(Member member, Boolean isOwner);
 
-    List<GroupMember> findGroupMemberByGroup_GroupId(Long groupId);
+    List<GroupMember> findGroupMemberByGroup_GroupIdAndIsOwnerIsFalse(Long groupId);
 
     List<GroupMember> findGroupMembersByGroup_GroupIdAndMember_IntraIdIn(Long groupId, List<Integer> MemberIntraId);
 
@@ -27,4 +27,11 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     void deleteAllByGroup_GroupId(Long groupId);
 
     long countByGroup_GroupIdAndMemberIn(Long groupId, List<Member> members);
+
+    GroupMember findGroupMemberByGroup_GroupIdAndIsOwner(Long groupId, boolean isOwner);
+//
+    List<GroupMember> findGroupMembersByMember_IntraIdAndIsOwner(Integer intraId, boolean isOwner);
+//
+    List<GroupMember> findGroupMembersByGroup_GroupIdInAndMember_IntraIdIn(List<Long> groupIds, List<Integer> memberIds);
+
 }

--- a/src/main/java/kr/where/backend/group/GroupService.java
+++ b/src/main/java/kr/where/backend/group/GroupService.java
@@ -36,8 +36,8 @@ public class GroupService {
 
 
         CreateGroupMemberDTO createGroupMemberDTO = CreateGroupMemberDTO.builder()
-                .groupId(group.getGroupId()).intraId(dto.getIntraId()).isOwner(true).build();
-        groupMemberService.createGroupMember(createGroupMemberDTO);
+                .groupId(group.getGroupId()).intraId(dto.getIntraId()).build();
+        groupMemberService.createGroupMember(createGroupMemberDTO, true);
         return ResponseGroupDto.from(group);
     }
 
@@ -45,10 +45,10 @@ public class GroupService {
         RequestGroupMemberDTO requestGroupMemberDTO = RequestGroupMemberDTO.builder().intraId(dto.getIntraId()).build();
         List<ResponseGroupMemberDTO> groupIds = groupMemberService.findGroupIdByIntraId(dto.getIntraId());
         groupIds.stream().forEach(c -> System.out.println(c));
-        if (groupIds.stream()
-                .filter(id -> findGroupNameById(id.getGroupId()).equals(dto.getGroupName()))
-                .count() != 0)
-            throw new RuntimeException("그룹 이름 중복");
+//        if (groupIds.stream()
+//                .filter(id -> findGroupNameById(id.getGroupId()).equals(dto.getGroupName()))
+//                .count() != 0)
+//            throw new GroupException.DuplicatedGroupNameException();
     }
 
     /* group 이 존재 하는지 유효성 검사 */

--- a/src/main/java/kr/where/backend/group/dto/groupmember/CreateGroupMemberDTO.java
+++ b/src/main/java/kr/where/backend/group/dto/groupmember/CreateGroupMemberDTO.java
@@ -11,8 +11,6 @@ public class CreateGroupMemberDTO {
     private Integer intraId;
     private Long groupId;
     private String groupName;
-    @JsonProperty(value = "isOwner")
-    private Boolean isOwner;
 
     @Builder
     public CreateGroupMemberDTO(
@@ -23,9 +21,5 @@ public class CreateGroupMemberDTO {
         this.intraId = intraId;
         this.groupId = groupId;
         this.groupName = groupName;
-        this.isOwner = isOwner;
-    }
-    public Boolean getIsOwner() {
-        return isOwner;
     }
 }

--- a/src/main/java/kr/where/backend/group/dto/groupmember/ResponseGroupMemberListDTO.java
+++ b/src/main/java/kr/where/backend/group/dto/groupmember/ResponseGroupMemberListDTO.java
@@ -12,10 +12,10 @@ public class ResponseGroupMemberListDTO {
     private Long groupId;
     private String groupName;
     private int count;
-    private List<ResponseGroupMemberDTO> members;
+    private List<ResponseOneGroupMemberDTO> members;
 
     @Builder
-    public ResponseGroupMemberListDTO(Long groupId, String groupName, int count, List<ResponseGroupMemberDTO> members){
+    public ResponseGroupMemberListDTO(Long groupId, String groupName, int count, List<ResponseOneGroupMemberDTO> members){
         this.groupId = groupId;
         this.groupName = groupName;
         this.count = count;

--- a/src/main/java/kr/where/backend/group/dto/groupmember/ResponseOneGroupMemberDTO.java
+++ b/src/main/java/kr/where/backend/group/dto/groupmember/ResponseOneGroupMemberDTO.java
@@ -1,0 +1,33 @@
+package kr.where.backend.group.dto.groupmember;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResponseOneGroupMemberDTO {
+
+    private Integer intraId;
+    private String intraName;
+    private String grade;
+    private String image;
+    private String comment;
+    private boolean inCluster;
+    private boolean agree;
+    private Long defaultGroupId;
+    private String location;
+
+    @Builder
+    public ResponseOneGroupMemberDTO(Integer intraId, String intraName, String grade, String image, String comment, boolean inCluster, boolean agree, Long defaultGroupId, String location) {
+        this.intraId = intraId;
+        this.intraName = intraName;
+        this.grade = grade;
+        this.image = image;
+        this.comment = comment;
+        this.inCluster = inCluster;
+        this.agree = agree;
+        this.defaultGroupId = defaultGroupId;
+        this.location = location;
+    }
+}


### PR DESCRIPTION
- 멤버 api와 반환 스키마 통일하기 위해서 ResponseOneGroupMemberDTO 추가
- 기본 그룹에서 친구 삭제시 다른 모든 그룹에서 해당 친구 삭제하는 기능 추가
- 위 기능 테스트 코드 추가
- 그룹에 멤버를 추가할 때 프론트 측에서 Is_Owner 값을 전달 받아 분기 했었는데, 백에서 처리하기 위해 Is_Owner 값을 그룹을 생성될 때, 그룹 주인이 is_Owner (true) 로 들어가는 상황을 제외하고 나머지 경우 is_Owner(false) 로 처리