### PR TITLE
Feat/security context holder

### DIFF
--- a/src/main/java/kr/where/backend/auth/authUserInfo/AuthUserInfo.java
+++ b/src/main/java/kr/where/backend/auth/authUserInfo/AuthUserInfo.java
@@ -1,0 +1,23 @@
+package kr.where.backend.auth.authUserInfo;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Getter
+public class AuthUserInfo {
+    private Integer intraId;
+    private String intraName;
+    private Long defaultGroupId;
+
+    @Builder
+    public AuthUserInfo(final Integer intraId, final String intraName, final Long defaultGroupId) {
+        this.intraId = intraId;
+        this.intraName = intraName;
+        this.defaultGroupId = defaultGroupId;
+    }
+
+    public static AuthUserInfo of() {
+        return (AuthUserInfo) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}

--- a/src/main/java/kr/where/backend/jwt/JwtService.java
+++ b/src/main/java/kr/where/backend/jwt/JwtService.java
@@ -13,6 +13,7 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Stream;
+import kr.where.backend.auth.authUserInfo.AuthUserInfo;
 import kr.where.backend.jwt.dto.ReIssue;
 import kr.where.backend.jwt.exception.JwtException;
 import kr.where.backend.jwt.exception.JwtException.InvalidJwtToken;
@@ -171,8 +172,14 @@ public class JwtService {
         final Member member = memberService.findOne(intraId)
                 .orElseThrow(MemberException.NoMemberException::new);
 
+        final AuthUserInfo authUserInfo = AuthUserInfo.builder()
+                .intraId(member.getIntraId())
+                .intraName(member.getIntraName())
+                .defaultGroupId(member.getDefaultGroupId())
+                .build();
+
         //Authentication 객체 생성
-        return new UsernamePasswordAuthenticationToken(member, "", authorities);
+        return new UsernamePasswordAuthenticationToken(authUserInfo, "", authorities);
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,9 +4,9 @@ spring:
       client:
         registration:
           42seoul:
-            client-id: u-s4t2ud-5ea817e12378a0c49e7619b430ca649d671fc6764a8b252bf0dd3f09febf76c5
-            client-secret: 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
-            redirect-uri: http://13.209.149.15:8080/login/oauth2/code/42seoul
+            client-id: u-s4t2ud-0404f8397c5fd585edfe6d3c8143f5f3d784ff51cca0e5c4b970291d032dbeaa
+            client-secret: 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
+            redirect-uri: http://localhost:8080/login/oauth2/code/42seoul
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_basic
         provider:
@@ -15,16 +15,16 @@ spring:
             token-uri: https://api.intra.42.fr/oauth/token
             user-info-uri: https://api.intra.42.fr/v2/me
             user-name-attribute: id
-#jwt:
-#  token:
-#    secret: NiOeyFbN1Gqo10bPgUyTFsRMkJpGLXSvGP04eFqj5B30r5TcrtlSXfQ7TndvYjNvfkEKLqILn0j1SmKODO1Yw3JpBBgI3nVPEahqxeY8qbPSFGyzyEVxnl4AQcrnVneI
-#
-#accesstoken:
-#  expiration:
-#    time: 60000
-#
-#refreshtoken:
-#  expiration:
-#    time: 12096
-#
-#issuer: where42
+jwt:
+  token:
+    secret: NiOeyFbN1Gqo10bPgUyTFsRMkJpGLXSvGP04eFqj5B30r5TcrtlSXfQ7TndvYjNvfkEKLqILn0j1SmKODO1Yw3JpBBgI3nVPEahqxeY8qbPSFGyzyEVxnl4AQcrnVneI
+
+accesstoken:
+  expiration:
+    time: 60000
+
+refreshtoken:
+  expiration:
+    time: 12096
+
+issuer: where42


### PR DESCRIPTION
## Issue
- AuthUserInfo를 security context holder에 저장합니다
- member를 저장하는 기존 방식에서 하나의 가벼운 class를 저장하는 방식으로 변환했습니다
- authUserInfo에서는 intraId, intraName, defaultGroupId를 가지게 됩니다

## security context holder에 인증 정보를 저장하면 전역적으로 사용할 수 있게 됩니다
- 인증에 성공한 user의 정보를 어떻게 전역적으로 사용할 수 있느냐?
- SecurityContext 및 SecurityContextHolder의 구조와 스프링 시큐리티 내부의 어느 필터에서 사용되는 지를 알아야합니다
### SecurityContext ❓
- authentication 객체가 저장되는 장소입니다
- SecurityContextHolder의 전략방식에 따라 저장하는 방식이 다르지만, 일반적으로는 Thread local에 저장한다고 생각하는게 편합니다
- Thread local -> 쓰레드마다 갖는 고유 저장 공간이라고 생각하면 됩니다

### SecurityContextHolder❓
- SecurityContext를 감싸는 하나의 Wrapper class 입니다
- 일반적으로 SecurityContext 저장을 위한 Thread local을 가지고 있는 객체라고 생각하면 됩니다
- SecurityContext 객체의 저장 방식(전략, Strategy)을 지정 합니다
`MODE_THREADLOCAL` : 스레드당 SecurityContext 객체를 할당, 기본값
`MODE_INHERITABLETHREADLOCAL`: 메인, 자식 스레드에서 동일한 SecurityContext 사용
`MODE_GLOBAL`: 프래그램에서 딱 하나의 SecurityContext만 저장
- 각 전략에 따른 전략 class가 존재하고 SecurityContextHolder의 method 대부분 이 전략의 class 인스턴스에게 작업을 위임합니다
-> 쉽게, 전략 class에 주도권을 넘겨준다고 생각하면 편합니다

### 결론
그래서 우리는 인증 성공한 유저의 중요한 정보를 전역적으로 사용가능하다!