### PR TITLE
137 update in cluster info more faster

### DIFF
--- a/src/main/java/kr/where/backend/api/HaneApiService.java
+++ b/src/main/java/kr/where/backend/api/HaneApiService.java
@@ -27,9 +27,8 @@ public class HaneApiService {
 	 */
 	public Hane getHaneInfo(final String name, final String token) {
 		try {
-			return JsonMapper
-				.mapping(HttpResponse.getMethod(HttpHeader.requestHaneInfo(token), UriBuilder.hane(name)),
-					Hane.class);
+			return JsonMapper.mapping(HttpResponse.getMethod(HttpHeader.requestHaneInfo(token), UriBuilder.hane(name)),
+				Hane.class);
 		} catch (RequestException exception) {
 			log.warn("[hane] {} : {}", name, exception.toString());
 			return new Hane();
@@ -38,9 +37,10 @@ public class HaneApiService {
 
 	@Transactional
 	public void updateInClusterOne(final Member member) {
-		if (member.isAgree() && LocalDateTime.now().minusMinutes(3).isAfter(member.getInClusterUpdatedAt())) {
-			member.setInCluster(getHaneInfo(member.getIntraName(),
-				oauthTokenService.findAccessToken(HANE_TOKEN)));
+		if (member.isAgree() && (member.getInClusterUpdatedAt() == null || LocalDateTime.now()
+			.minusMinutes(3)
+			.isAfter(member.getInClusterUpdatedAt()))) {
+			member.setInCluster(getHaneInfo(member.getIntraName(), oauthTokenService.findAccessToken(HANE_TOKEN)));
 
 			log.info("member {}의 inCluster가 변경되었습니다", member.getIntraName());
 		}

--- a/src/main/java/kr/where/backend/api/HaneApiService.java
+++ b/src/main/java/kr/where/backend/api/HaneApiService.java
@@ -5,14 +5,20 @@ import kr.where.backend.api.http.HttpHeader;
 import kr.where.backend.api.http.HttpResponse;
 import kr.where.backend.api.http.UriBuilder;
 import kr.where.backend.api.json.Hane;
+import kr.where.backend.member.Member;
+import kr.where.backend.oauthtoken.OAuthTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class HaneApiService {
+    private final OAuthTokenService oauthTokenService;
+    private static final String HANE_TOKEN = "hane";
+
     /**
      * hane api 호출하여 in, out state 반환
      */
@@ -25,5 +31,14 @@ public class HaneApiService {
             log.warn("[hane] {} : {}", name, exception.toString());
             return new Hane();
         }
+    }
+
+    @Transactional
+    public void updateInClusterOne(final Member member) {
+
+        member.setInCluster(getHaneInfo(member.getIntraName(),
+            oauthTokenService.findAccessToken(HANE_TOKEN)));
+
+        log.info("member {}의 inCluster가 변경되었습니다", member.getIntraName());
     }
 }

--- a/src/main/java/kr/where/backend/api/HaneApiService.java
+++ b/src/main/java/kr/where/backend/api/HaneApiService.java
@@ -36,7 +36,7 @@ public class HaneApiService {
 	}
 
 	@Transactional
-	public void updateInClusterOne(final Member member) {
+	public void updateInClusterForMainPage(final Member member) {
 		if (member.isAgree() && (member.getInClusterUpdatedAt() == null || LocalDateTime.now()
 			.minusMinutes(3)
 			.isAfter(member.getInClusterUpdatedAt()))) {

--- a/src/main/java/kr/where/backend/api/HaneApiService.java
+++ b/src/main/java/kr/where/backend/api/HaneApiService.java
@@ -37,9 +37,7 @@ public class HaneApiService {
 
 	@Transactional
 	public void updateInClusterForMainPage(final Member member) {
-		if (member.isAgree() && (member.getInClusterUpdatedAt() == null || LocalDateTime.now()
-			.minusMinutes(3)
-			.isAfter(member.getInClusterUpdatedAt()))) {
+		if (member.isAgree()) {
 			member.setInCluster(getHaneInfo(member.getIntraName(), oauthTokenService.findAccessToken(HANE_TOKEN)));
 
 			log.info("member {}의 inCluster가 변경되었습니다", member.getIntraName());

--- a/src/main/java/kr/where/backend/api/HaneApiService.java
+++ b/src/main/java/kr/where/backend/api/HaneApiService.java
@@ -1,5 +1,7 @@
 package kr.where.backend.api;
 
+import java.time.LocalDateTime;
+
 import kr.where.backend.api.exception.RequestException;
 import kr.where.backend.api.http.HttpHeader;
 import kr.where.backend.api.http.HttpResponse;
@@ -9,6 +11,7 @@ import kr.where.backend.member.Member;
 import kr.where.backend.oauthtoken.OAuthTokenService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,29 +19,30 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class HaneApiService {
-    private final OAuthTokenService oauthTokenService;
-    private static final String HANE_TOKEN = "hane";
+	private final OAuthTokenService oauthTokenService;
+	private static final String HANE_TOKEN = "hane";
 
-    /**
-     * hane api 호출하여 in, out state 반환
-     */
-    public Hane getHaneInfo(final String name, final String token) {
-        try {
-            return JsonMapper
-                    .mapping(HttpResponse.getMethod(HttpHeader.requestHaneInfo(token), UriBuilder.hane(name)),
-                            Hane.class);
-        } catch (RequestException exception) {
-            log.warn("[hane] {} : {}", name, exception.toString());
-            return new Hane();
-        }
-    }
+	/**
+	 * hane api 호출하여 in, out state 반환
+	 */
+	public Hane getHaneInfo(final String name, final String token) {
+		try {
+			return JsonMapper
+				.mapping(HttpResponse.getMethod(HttpHeader.requestHaneInfo(token), UriBuilder.hane(name)),
+					Hane.class);
+		} catch (RequestException exception) {
+			log.warn("[hane] {} : {}", name, exception.toString());
+			return new Hane();
+		}
+	}
 
-    @Transactional
-    public void updateInClusterOne(final Member member) {
+	@Transactional
+	public void updateInClusterOne(final Member member) {
+		if (member.isAgree() && LocalDateTime.now().minusMinutes(3).isAfter(member.getInClusterUpdatedAt())) {
+			member.setInCluster(getHaneInfo(member.getIntraName(),
+				oauthTokenService.findAccessToken(HANE_TOKEN)));
 
-        member.setInCluster(getHaneInfo(member.getIntraName(),
-            oauthTokenService.findAccessToken(HANE_TOKEN)));
-
-        log.info("member {}의 inCluster가 변경되었습니다", member.getIntraName());
-    }
+			log.info("member {}의 inCluster가 변경되었습니다", member.getIntraName());
+		}
+	}
 }

--- a/src/main/java/kr/where/backend/api/json/CadetPrivacy.java
+++ b/src/main/java/kr/where/backend/api/json/CadetPrivacy.java
@@ -25,17 +25,23 @@ public class CadetPrivacy {
     private boolean active;
     @Schema(description = "42서울 등록일")
     private String created_at;
-
+    @Schema(description = "캠퍼스 소속")
+    private Integer campus;
     protected CadetPrivacy() {}
 
     @Builder
-    public CadetPrivacy(Integer id, String login, String location, String small_image, boolean active, String created_at) {
+    public CadetPrivacy(
+            final Integer id, final String login, final String location,
+            final String small_image, final boolean active, final String created_at,
+            final Integer campusId
+    ) {
         this.id = id;
         this.login = login;
         this.location = location;
         this.image = Image.create(Versions.create(small_image));
         this.active = active;
         this.created_at = created_at;
+        this.campus = campusId;
     }
 
     public static CadetPrivacy of(final Map<String, Object> attributes) {
@@ -47,6 +53,7 @@ public class CadetPrivacy {
                 smallUrl = versions.get("small");
             }
         }
+        Map<String, Object> campus = (Map<String, Object>) attributes.get("campus");
 
         return CadetPrivacy.builder()
                 .id((Integer) attributes.get("id"))
@@ -55,6 +62,7 @@ public class CadetPrivacy {
                 .small_image(smallUrl)
                 .active(attributes.get("active") != null && (boolean) attributes.get("active"))
                 .created_at((String) attributes.get("created_at"))
+                .campusId((Integer) campus.get("id"))
                 .build();
     }
 }

--- a/src/main/java/kr/where/backend/api/json/CadetPrivacy.java
+++ b/src/main/java/kr/where/backend/api/json/CadetPrivacy.java
@@ -3,6 +3,8 @@ package kr.where.backend.api.json;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import lombok.*;
@@ -53,7 +55,7 @@ public class CadetPrivacy {
                 smallUrl = versions.get("small");
             }
         }
-        Map<String, Object> campus = (Map<String, Object>) attributes.get("campus");
+        List<Map<String, Object>> campus = (List<Map<String, Object>>) attributes.get("campus");
 
         return CadetPrivacy.builder()
                 .id((Integer) attributes.get("id"))
@@ -62,7 +64,7 @@ public class CadetPrivacy {
                 .small_image(smallUrl)
                 .active(attributes.get("active") != null && (boolean) attributes.get("active"))
                 .created_at((String) attributes.get("created_at"))
-                .campusId((Integer) campus.get("id"))
+                .campusId((Integer) campus.get(0).get("id"))
                 .build();
     }
 }

--- a/src/main/java/kr/where/backend/auth/oauth2login/OAuth2FailureHandler.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/OAuth2FailureHandler.java
@@ -18,6 +18,6 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
     public void onAuthenticationFailure(
             HttpServletRequest request, HttpServletResponse response, AuthenticationException exception)
             throws IOException, ServletException {
-        response.sendRedirect("https://test.where42.kr/login-fail");
+        response.sendRedirect("https://where42.kr/login-fail");
     }
 }

--- a/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
@@ -60,8 +60,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     jwtService.createRefreshToken(cadetPrivacy.getId(), cadetPrivacy.getLogin())
             );
         }
-        response.setHeader("accessToken ", "123234535453");
-        response.setHeader("refreshToken " , "rrrognornvornornr");
+//        response.setHeader("accessToken ", "123234535453");
+//        response.setHeader("refreshToken " , "rrrognornvornornr");
         getRedirectStrategy()
                 .sendRedirect(
                         request,

--- a/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
@@ -67,7 +67,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                         request,
                         response,
                         UriComponentsBuilder
-                                .fromUriString("https://test.where42.kr")
+                                .fromUriString("http://test.where42.kr")
                                 .queryParam("intraId", member.getIntraId())
                                 .queryParam("agreement", member.isAgree())
                                 .build()

--- a/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
@@ -63,7 +63,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                         request,
                         response,
                         UriComponentsBuilder
-                                .fromUriString("https://test.where42.kr")
+                                .fromUriString("https://where42.kr")
                                 .queryParam("intraId", member.getIntraId())
                                 .queryParam("agreement", member.isAgree())
                                 .build()

--- a/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/OAuth2SuccessHandler.java
@@ -67,7 +67,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                         request,
                         response,
                         UriComponentsBuilder
-                                .fromUriString("http://test.where42.kr")
+                                .fromUriString("https://test.where42.kr")
                                 .queryParam("intraId", member.getIntraId())
                                 .queryParam("agreement", member.isAgree())
                                 .build()

--- a/src/main/java/kr/where/backend/auth/oauth2login/cookie/CookieShop.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/cookie/CookieShop.java
@@ -14,7 +14,7 @@ public class CookieShop {
         cookie.setMaxAge(expiry);
         cookie.setPath("/");
         // cookie.setSecure(true);
-        // cookie.setHttpOnly(true);
+         cookie.setHttpOnly(true);
 
         response.addCookie(cookie);
     }

--- a/src/main/java/kr/where/backend/auth/oauth2login/cookie/CookieShop.java
+++ b/src/main/java/kr/where/backend/auth/oauth2login/cookie/CookieShop.java
@@ -13,8 +13,6 @@ public class CookieShop {
 
         cookie.setMaxAge(expiry);
         cookie.setPath("/");
-        // cookie.setSecure(true);
-         cookie.setHttpOnly(true);
 
         response.addCookie(cookie);
     }

--- a/src/main/java/kr/where/backend/group/GroupMemberService.java
+++ b/src/main/java/kr/where/backend/group/GroupMemberService.java
@@ -153,7 +153,10 @@ public class GroupMemberService {
         final List<GroupMember> groupMembers = groupMemberRepository.findGroupMemberByGroup_GroupIdAndIsOwnerIsFalse(groupId);
 
         return groupMembers.stream()
-            .peek(m -> haneApiService.updateInClusterForMainPage(m.getMember()))
+            .peek(m -> {
+                if (m.getMember().isPossibleToUpdateInCluster())
+                    haneApiService.updateInClusterForMainPage(m.getMember());
+            })
             .map(m -> ResponseOneGroupMemberDTO.builder()
                 .intraId(m.getMember().getIntraId())
                 .image(m.getMember().getImage())

--- a/src/main/java/kr/where/backend/group/GroupMemberService.java
+++ b/src/main/java/kr/where/backend/group/GroupMemberService.java
@@ -152,10 +152,8 @@ public class GroupMemberService {
 
         final List<GroupMember> groupMembers = groupMemberRepository.findGroupMemberByGroup_GroupIdAndIsOwnerIsFalse(groupId);
 
-        // 하네 업데이트
-
         return groupMembers.stream()
-            .peek(m -> haneApiService.updateInClusterOne(m.getMember()))
+            .peek(m -> haneApiService.updateInClusterForMainPage(m.getMember()))
             .map(m -> ResponseOneGroupMemberDTO.builder()
                 .intraId(m.getMember().getIntraId())
                 .image(m.getMember().getImage())

--- a/src/main/java/kr/where/backend/group/GroupMemberService.java
+++ b/src/main/java/kr/where/backend/group/GroupMemberService.java
@@ -3,6 +3,7 @@ package kr.where.backend.group;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import kr.where.backend.api.HaneApiService;
 import kr.where.backend.auth.authUser.AuthUser;
 import kr.where.backend.group.dto.groupmember.*;
 import kr.where.backend.group.entity.Group;
@@ -24,7 +25,7 @@ public class GroupMemberService {
     private final GroupMemberRepository groupMemberRepository;
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
-
+    private final HaneApiService haneApiService;
     /**
      * 그룹에 그룹 멤버를 추가
      * 인자로 들어온 groupId가 존재하지 않다면 Exception
@@ -151,15 +152,19 @@ public class GroupMemberService {
 
         final List<GroupMember> groupMembers = groupMemberRepository.findGroupMemberByGroup_GroupIdAndIsOwnerIsFalse(groupId);
 
+        // 하네 업데이트
+
         return groupMembers.stream()
-                .map(m -> ResponseOneGroupMemberDTO.builder()
+            .peek(m -> haneApiService.updateInClusterOne(m.getMember()))
+            .map(m -> ResponseOneGroupMemberDTO.builder()
                 .intraId(m.getMember().getIntraId())
                 .image(m.getMember().getImage())
                 .comment(m.getMember().getComment())
                 .intraName(m.getMember().getIntraName())
                 .inCluster(m.getMember().isInCluster())
                 .location(m.getMember().getLocation().getLocation())
-                .build()).toList();
+                .build()
+            ).toList();
     }
 
     /**

--- a/src/main/java/kr/where/backend/group/GroupMemberService.java
+++ b/src/main/java/kr/where/backend/group/GroupMemberService.java
@@ -172,6 +172,7 @@ public class GroupMemberService {
      * @param authUser
      * @return List<ResponseGroupMemberListDTO>
      */
+    @Transactional
     public List<ResponseGroupMemberListDTO> findMyAllGroupInformation(final AuthUser authUser){
         final List<ResponseGroupMemberDTO> groups = findGroupIdByIntraId(authUser.getIntraId());
 

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -118,6 +118,7 @@ public class Member {
 
 	public void setInClusterUpdatedAtForTest() {
 		this.inClusterUpdatedAt = inClusterUpdatedAt.minusMinutes(4);
+		// this.inClusterUpdatedAt = null;
 	}
 
 	public void setImage(final String image) {

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -39,6 +39,8 @@ public class Member {
 
 	private boolean inCluster;
 
+	private LocalDateTime inClusterUpdatedAt;
+
 	@Column(nullable = false)
 	private boolean blackHole;
 
@@ -71,6 +73,7 @@ public class Member {
 		this.grade = cadetPrivacy.getCreated_at();
 		this.image = cadetPrivacy.getImage().getVersions().getSmall();
 		this.inCluster = hane.getInoutState().equals("IN");
+		this.inClusterUpdatedAt = LocalDateTime.now();
 		this.agree = true;
 		this.blackHole = false;
 	}
@@ -107,9 +110,14 @@ public class Member {
 
 	public void setInCluster(final Hane hane) {
 		this.inCluster = Objects.equals(hane.getInoutState(), "IN");
+		this.inClusterUpdatedAt = LocalDateTime.now();
 
 		if (this.inCluster == false)
 			this.location.initLocation();
+	}
+
+	public void setInClusterUpdatedAtForTest() {
+		this.inClusterUpdatedAt = inClusterUpdatedAt.minusMinutes(4);
 	}
 
 	public void setImage(final String image) {

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -116,10 +116,10 @@ public class Member {
 			this.location.initLocation();
 	}
 
-	public void setInClusterUpdatedAtForTest() {
-		this.inClusterUpdatedAt = inClusterUpdatedAt.minusMinutes(4);
-		// this.inClusterUpdatedAt = null;
-	}
+	// public void setInClusterUpdatedAtForTest() {
+	// 	this.inClusterUpdatedAt = inClusterUpdatedAt.minusMinutes(4);
+	// 	// this.inClusterUpdatedAt = null;
+	// }
 
 	public boolean isPossibleToUpdateInCluster() {
 		if (inClusterUpdatedAt == null || LocalDateTime.now()

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -121,6 +121,14 @@ public class Member {
 		// this.inClusterUpdatedAt = null;
 	}
 
+	public boolean isPossibleToUpdateInCluster() {
+		if (inClusterUpdatedAt == null || LocalDateTime.now()
+			.minusMinutes(3)
+			.isAfter(inClusterUpdatedAt))
+			return true;
+		return false;
+	}
+
 	public void setImage(final String image) {
 		this.image = image;
 	}

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -123,7 +123,7 @@ public class Member {
 
 	public boolean isPossibleToUpdateInCluster() {
 		if (inClusterUpdatedAt == null || LocalDateTime.now()
-			.minusMinutes(3)
+			.minusMinutes(5)
 			.isAfter(inClusterUpdatedAt))
 			return true;
 		return false;

--- a/src/main/java/kr/where/backend/member/MemberController.java
+++ b/src/main/java/kr/where/backend/member/MemberController.java
@@ -102,29 +102,4 @@ public class MemberController implements MemberApiDocs {
 
 		return ResponseEntity.ok(responseMemberDto);
 	}
-
-	/**
-	 * dummy member 10명 생성
-	 *
-	 * @return ResponseEntity(ResponseMemberDTOList)
-	 * @deprecated test용 dummy
-	 */
-	@PostMapping("/dummy")
-	public ResponseEntity<List<ResponseMemberDTO>> createDummyAgreeMembers() {
-		List<ResponseMemberDTO> responseMemberDTOList = new ArrayList<>();
-
-		for (int i = 0; i < 10; i++) {
-			CadetPrivacy cadetPrivacy = new CadetPrivacy(1 + i, "member" + i, "c1r1s" + i,
-				"https://ibb.co/94KmxcT", true, "2022-10-31", 29);
-			Hane hane = Hane.create("IN");
-
-			Member member = memberService.createAgreeMember(cadetPrivacy, hane);
-			ResponseMemberDTO responseMemberDto = ResponseMemberDTO.builder().member(member).build();
-			responseMemberDTOList.add(responseMemberDto);
-		}
-
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.location(URI.create("http://3.35.149.29:8080/v3/main"))
-			.body(responseMemberDTOList);
-	}
 }

--- a/src/main/java/kr/where/backend/member/MemberController.java
+++ b/src/main/java/kr/where/backend/member/MemberController.java
@@ -115,7 +115,7 @@ public class MemberController implements MemberApiDocs {
 
 		for (int i = 0; i < 10; i++) {
 			CadetPrivacy cadetPrivacy = new CadetPrivacy(1 + i, "member" + i, "c1r1s" + i,
-				"https://ibb.co/94KmxcT", true, "2022-10-31");
+				"https://ibb.co/94KmxcT", true, "2022-10-31", 29);
 			Hane hane = Hane.create("IN");
 
 			Member member = memberService.createAgreeMember(cadetPrivacy, hane);

--- a/src/main/java/kr/where/backend/member/MemberService.java
+++ b/src/main/java/kr/where/backend/member/MemberService.java
@@ -164,9 +164,7 @@ public class MemberService {
 		final Member member = memberRepository.findByIntraId(intraId)
 			.orElseThrow(MemberException.NoMemberException::new);
 
-		// 하네 업데이트
-
-		haneApiServiceService.updateInClusterOne(member);
+		haneApiServiceService.updateInClusterForMainPage(member);
 
 		return ResponseMemberDTO.builder().member(member).build();
 	}

--- a/src/main/java/kr/where/backend/member/MemberService.java
+++ b/src/main/java/kr/where/backend/member/MemberService.java
@@ -1,5 +1,6 @@
 package kr.where.backend.member;
 
+import kr.where.backend.api.HaneApiService;
 import kr.where.backend.api.json.CadetPrivacy;
 import kr.where.backend.api.json.Hane;
 import kr.where.backend.auth.authUser.AuthUser;
@@ -27,6 +28,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final GroupService groupService;
 	private final LocationService locationService;
+	private final HaneApiService haneApiServiceService;
 	private final static Integer CAMPUS_ID = 29;
 	/**
 	 * if (이미 존재하는 멤버)
@@ -160,6 +162,10 @@ public class MemberService {
 	public ResponseMemberDTO findOneByIntraId(final Integer intraId) {
 		final Member member = memberRepository.findByIntraId(intraId)
 			.orElseThrow(MemberException.NoMemberException::new);
+
+		// 하네 업데이트
+
+		haneApiServiceService.updateInClusterOne(member);
 
 		return ResponseMemberDTO.builder().member(member).build();
 	}

--- a/src/main/java/kr/where/backend/member/MemberService.java
+++ b/src/main/java/kr/where/backend/member/MemberService.java
@@ -27,7 +27,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final GroupService groupService;
 	private final LocationService locationService;
-
+	private final static Integer CAMPUS_ID = 29;
 	/**
 	 * if (이미 존재하는 멤버)
 	 *      throw duplicate_exception
@@ -73,6 +73,7 @@ public class MemberService {
 	 */
 	@Transactional
 	public Member createDisagreeMember(final CadetPrivacy cadetPrivacy) {
+		isSeoulCampus(cadetPrivacy);
 		final Member member = new Member(cadetPrivacy);
 		memberRepository.save(member);
 		locationService.create(member, cadetPrivacy.getLocation());
@@ -176,6 +177,20 @@ public class MemberService {
 
 	public Optional<List<Member>> findAgreeMembers() {
 		return memberRepository.findAllByAgreeTrue();
+	}
+
+	/**
+	 * 회원 가입하려는 사용자가 서울 캠퍼스 인지 판별
+	 * Oauth2SuccessHandler.class에서 사용
+	 * disagree member entity 만들때 사용
+	 *
+	 * @param cadetPrivacy
+	 * @throws MemberException
+	 */
+	public void isSeoulCampus(final CadetPrivacy cadetPrivacy) {
+		if (!cadetPrivacy.getCampus().equals(CAMPUS_ID)) {
+			throw new MemberException.NotFromSeoulCampus();
+		}
 	}
 }
 

--- a/src/main/java/kr/where/backend/member/MemberService.java
+++ b/src/main/java/kr/where/backend/member/MemberService.java
@@ -164,7 +164,8 @@ public class MemberService {
 		final Member member = memberRepository.findByIntraId(intraId)
 			.orElseThrow(MemberException.NoMemberException::new);
 
-		haneApiServiceService.updateInClusterForMainPage(member);
+		if (member.isPossibleToUpdateInCluster())
+			haneApiServiceService.updateInClusterForMainPage(member);
 
 		return ResponseMemberDTO.builder().member(member).build();
 	}

--- a/src/main/java/kr/where/backend/member/MemberService.java
+++ b/src/main/java/kr/where/backend/member/MemberService.java
@@ -159,6 +159,7 @@ public class MemberService {
 	 * @return responseMemberDTO
 	 * @throws MemberException.NoMemberException 존재하지 않는 멤버입니다
 	 */
+	@Transactional
 	public ResponseMemberDTO findOneByIntraId(final Integer intraId) {
 		final Member member = memberRepository.findByIntraId(intraId)
 			.orElseThrow(MemberException.NoMemberException::new);

--- a/src/main/java/kr/where/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/kr/where/backend/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public enum MemberErrorCode implements ErrorCode {
 
 	NO_MEMBER(1000, "존재하지 않는 맴버입니다."),
-	DUPLICATED_MEMBER(1001, "이미 존재하는 맴버입니다.");
+	DUPLICATED_MEMBER(1001, "이미 존재하는 맴버입니다."),
+	NOT_FROM_SEOUL_CADET(1002, "서울 캠퍼스 카뎃이 아닙니다.");
 
 	private final int errorCode;
 	private final String errorMessage;

--- a/src/main/java/kr/where/backend/member/exception/MemberException.java
+++ b/src/main/java/kr/where/backend/member/exception/MemberException.java
@@ -19,4 +19,10 @@ public class MemberException extends CustomException {
 			super(MemberErrorCode.DUPLICATED_MEMBER);
 		}
 	}
+
+	public static class NotFromSeoulCampus extends MemberException {
+		public NotFromSeoulCampus() {
+			super(MemberErrorCode.NOT_FROM_SEOUL_CADET);
+		}
+	}
 }

--- a/src/main/java/kr/where/backend/member/swagger/MemberApiDocs.java
+++ b/src/main/java/kr/where/backend/member/swagger/MemberApiDocs.java
@@ -105,16 +105,4 @@ public interface MemberApiDocs {
 	)
 	@DeleteMapping("/comment")
 	ResponseEntity<ResponseMemberDTO> deleteComment(@AuthUserInfo final AuthUser authUser);
-
-	@Operation(summary = "1.5 createDummyAgreeMember API", description = "dummy 동의 맴버 생성 하는 POST API, dummy 멤버 10명 생성, 인자 필요 없음 (sign up 생기면 없어질 api 입니다!)",
-		parameters = {
-			@Parameter(name = "accessToken", description = "인증/인가 확인용 accessToken", in = ParameterIn.HEADER),
-		},
-		responses = {
-			@ApiResponse(responseCode = "201", description = "맴버 생성 성공", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMemberDTO.class)))),
-			@ApiResponse(responseCode = "1001", description = "이미 존재하는 맴버입니다.", content = @Content(schema = @Schema(implementation = MemberException.DuplicatedMemberException.class)))
-		}
-	)
-	@PostMapping("/dummy")
-	ResponseEntity<List<ResponseMemberDTO>> createDummyAgreeMembers();
 }

--- a/src/main/java/kr/where/backend/update/UpdateService.java
+++ b/src/main/java/kr/where/backend/update/UpdateService.java
@@ -179,7 +179,7 @@ public class UpdateService {
     @Transactional
     @Scheduled(cron = "0 0 0/1 1/1 * ?")
     public void updateInCluster() {
-        log.info("hane 자리 없데이트를 시작합니다!");
+        log.info("hane 자리 업데이트를 시작합니다!");
         final List<Member> agreeMembers = memberService.findAgreeMembers()
                 .orElseThrow(NoMemberException::new);
 
@@ -190,6 +190,6 @@ public class UpdateService {
                             )
                     )
         );
-        log.info("hane 자리 없데이트를 끝냅니다!");
+        log.info("hane 자리 업데이트를 끝냅니다!");
     }
 }

--- a/src/test/java/kr/where/backend/group/GroupMemberServiceTest.java
+++ b/src/test/java/kr/where/backend/group/GroupMemberServiceTest.java
@@ -64,7 +64,7 @@ public class GroupMemberServiceTest {
         Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
         authUser = new AuthUser(11111, "hjeong", 1L);
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(11111, "hjeong", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(11111, "hjeong", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
         Member member = memberService.createAgreeMember(cadetPrivacy, hane);
         authUser.setDefaultGroupId(member.getDefaultGroupId());
@@ -76,7 +76,7 @@ public class GroupMemberServiceTest {
     @Rollback
     public void 그룹_멤버_생성() throws Exception {
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
         authUser.setIntraId(22222);
         authUser.setIntraName("jnam");
@@ -96,19 +96,19 @@ public class GroupMemberServiceTest {
     }
 
     void 그룹_멤버_리스트_생성_후_저장(){
-        CadetPrivacy cadetPrivacy1 = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy1 = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
         authUser.setIntraId(22222);
         authUser.setIntraName("jnam");
         Hane hane1 = Hane.create("IN");
         memberService.createAgreeMember(cadetPrivacy1, hane1);
 
-        CadetPrivacy cadetPrivacy2 = new CadetPrivacy(22223, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy2 = new CadetPrivacy(22223, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
         authUser.setIntraId(22223);
         authUser.setIntraName("suhwpark");
         Hane hane2 = Hane.create("IN");
         memberService.createAgreeMember(cadetPrivacy2, hane2);
 
-        CadetPrivacy cadetPrivacy3 = new CadetPrivacy(22224, "jonhan", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy3 = new CadetPrivacy(22224, "jonhan", "c1r1s1", "image", true, "2022-10-31", 29);
         authUser.setIntraId(22224);
         authUser.setIntraName("jonhan");
         Hane hane3 = Hane.create("IN");
@@ -152,7 +152,7 @@ public class GroupMemberServiceTest {
     public void 그룹_멤버_삭제() throws Exception{
 
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
         authUser.setIntraId(22222);
         authUser.setIntraName("jnam");
         Hane hane = Hane.create("IN");
@@ -184,7 +184,7 @@ public class GroupMemberServiceTest {
 
         //given
         //멤버 한명 생성
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
         authUser.setIntraId(22222);
         authUser.setIntraName("jnam");

--- a/src/test/java/kr/where/backend/group/GroupMemberServiceTest.java
+++ b/src/test/java/kr/where/backend/group/GroupMemberServiceTest.java
@@ -76,14 +76,14 @@ public class GroupMemberServiceTest {
     @Rollback
     public void 그룹_멤버_생성() throws Exception {
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
-        authUser.setIntraId(22222);
+        authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
         memberService.createAgreeMember(cadetPrivacy, hane);
 
         createGroupMemberDTO = CreateGroupMemberDTO.builder()
-                .intraId(22222)
+                .intraId(99856)
                 .groupId(generalResponseGroupDTO.getGroupId())
                 .build();
         //when
@@ -96,16 +96,16 @@ public class GroupMemberServiceTest {
     }
 
     void 그룹_멤버_리스트_생성_후_저장(){
-        CadetPrivacy cadetPrivacy1 = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
-        authUser.setIntraId(22222);
+        CadetPrivacy cadetPrivacy1 = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
-        Hane hane1 = Hane.create("IN");
+        Hane hane1 = Hane.create("OUT");
         memberService.createAgreeMember(cadetPrivacy1, hane1);
 
-        CadetPrivacy cadetPrivacy2 = new CadetPrivacy(22223, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
-        authUser.setIntraId(22223);
+        CadetPrivacy cadetPrivacy2 = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+        authUser.setIntraId(135436);
         authUser.setIntraName("suhwpark");
-        Hane hane2 = Hane.create("IN");
+        Hane hane2 = Hane.create("OUT");
         memberService.createAgreeMember(cadetPrivacy2, hane2);
 
         CadetPrivacy cadetPrivacy3 = new CadetPrivacy(22224, "jonhan", "c1r1s1", "image", true, "2022-10-31", 29);
@@ -115,8 +115,8 @@ public class GroupMemberServiceTest {
         memberService.createAgreeMember(cadetPrivacy3, hane3);
 
         List<Integer> members = new ArrayList<>();
-        members.add(22222);
-        members.add(22223);
+        members.add(99856);
+        members.add(135436);
         members.add(22224);
         authUser.setIntraId(11111);
         authUser.setIntraName("hjeong");
@@ -141,7 +141,7 @@ public class GroupMemberServiceTest {
 
         //then
         for (ResponseOneGroupMemberDTO memberDTO : responseGroupMemberDTOS) {
-            System.out.println(memberDTO);
+            System.out.println(memberDTO.isInCluster());
         }
         assertEquals(3, responseGroupMemberDTOS.size());
     }
@@ -152,13 +152,13 @@ public class GroupMemberServiceTest {
     public void 그룹_멤버_삭제() throws Exception{
 
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
-        authUser.setIntraId(22222);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
         Hane hane = Hane.create("IN");
         memberService.createAgreeMember(cadetPrivacy, hane);
         createGroupMemberDTO = CreateGroupMemberDTO.builder()
-                .intraId(22222)
+                .intraId(99856)
                 .groupId(generalResponseGroupDTO.getGroupId())
                 .build();
         authUser.setIntraId(11111);
@@ -166,7 +166,7 @@ public class GroupMemberServiceTest {
         ResponseGroupMemberDTO responseGroupMemberDTO = groupMemberService.createGroupMember(createGroupMemberDTO, false, authUser);
 
         List<Integer> members = new ArrayList<>();
-        members.add(22222);
+        members.add(99856);
 
         //when
         List<ResponseGroupMemberDTO> responseGroupMemberDTO1 = groupMemberService.deleteFriendsList(
@@ -184,9 +184,9 @@ public class GroupMemberServiceTest {
 
         //given
         //멤버 한명 생성
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(22222, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
-        authUser.setIntraId(22222);
+        authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
         memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -197,22 +197,22 @@ public class GroupMemberServiceTest {
 
         //기본그룹에 추가
         createGroupMemberDTO = CreateGroupMemberDTO.builder()
-                .intraId(22222)
+                .intraId(99856)
                 .groupId(defaultResponseGroupDTO.getGroupId())
                 .build();
         ResponseGroupMemberDTO responseGroupMemberDTO = groupMemberService.createGroupMember(createGroupMemberDTO, false, authUser);
 
         //일반 그룹에 추가
         createGroupMemberDTO = CreateGroupMemberDTO.builder()
-                .intraId(22222)
+                .intraId(99856)
                 .groupId(generalResponseGroupDTO.getGroupId())
                 .build();
         groupMemberService.createGroupMember(createGroupMemberDTO, false, authUser);
         List<Integer> members = new ArrayList<>();
-        members.add(22222);
+        members.add(99856);
 
         //when
-        //기본그룹에서만 22222번 멤버를 삭제
+        //기본그룹에서만 99856번 멤버를 삭제
         List<ResponseGroupMemberDTO> delete_member = groupMemberService.deleteFriendsList(DeleteGroupMemberListDTO.builder()
                 .groupId(responseGroupMemberDTO.getGroupId())
                 .members(members).build(), authUser);
@@ -234,7 +234,7 @@ public class GroupMemberServiceTest {
         createGroupDto = new CreateGroupDTO("friends List");
         ResponseGroupDTO dto = groupService.createGroup(createGroupDto, authUser);
         List<Integer> member = new ArrayList<>();
-        member.add(22222);
+        member.add(99856);
 
         AddGroupMemberListDTO addGroupMemberListDTO = AddGroupMemberListDTO.builder()
                 .groupId(dto.getGroupId())

--- a/src/test/java/kr/where/backend/group/GroupMemberServiceTest.java
+++ b/src/test/java/kr/where/backend/group/GroupMemberServiceTest.java
@@ -58,13 +58,16 @@ public class GroupMemberServiceTest {
     private ResponseGroupDTO generalResponseGroupDTO;
 
     private AuthUser authUser;
+
+    private final static Integer CAMPUS_ID = 29;
+
     @BeforeEach
     public void setUp () {
 //         Given
         Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
         authUser = new AuthUser(11111, "hjeong", 1L);
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(11111, "hjeong", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(11111, "hjeong", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         Hane hane = Hane.create("IN");
         Member member = memberService.createAgreeMember(cadetPrivacy, hane);
         authUser.setDefaultGroupId(member.getDefaultGroupId());
@@ -76,7 +79,7 @@ public class GroupMemberServiceTest {
     @Rollback
     public void 그룹_멤버_생성() throws Exception {
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         Hane hane = Hane.create("IN");
         authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
@@ -96,19 +99,19 @@ public class GroupMemberServiceTest {
     }
 
     void 그룹_멤버_리스트_생성_후_저장(){
-        CadetPrivacy cadetPrivacy1 = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy1 = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
         Hane hane1 = Hane.create("OUT");
         memberService.createAgreeMember(cadetPrivacy1, hane1);
 
-        CadetPrivacy cadetPrivacy2 = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy2 = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         authUser.setIntraId(135436);
         authUser.setIntraName("suhwpark");
         Hane hane2 = Hane.create("OUT");
         memberService.createAgreeMember(cadetPrivacy2, hane2);
 
-        CadetPrivacy cadetPrivacy3 = new CadetPrivacy(22224, "jonhan", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy3 = new CadetPrivacy(22224, "jonhan", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         authUser.setIntraId(22224);
         authUser.setIntraName("jonhan");
         Hane hane3 = Hane.create("IN");
@@ -152,7 +155,7 @@ public class GroupMemberServiceTest {
     public void 그룹_멤버_삭제() throws Exception{
 
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         authUser.setIntraId(99856);
         authUser.setIntraName("jnam");
         Hane hane = Hane.create("IN");
@@ -184,7 +187,7 @@ public class GroupMemberServiceTest {
 
         //given
         //멤버 한명 생성
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(99856, "jnam", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         Hane hane = Hane.create("IN");
         authUser.setIntraId(99856);
         authUser.setIntraName("jnam");

--- a/src/test/java/kr/where/backend/group/GroupServiceTest.java
+++ b/src/test/java/kr/where/backend/group/GroupServiceTest.java
@@ -36,13 +36,16 @@ public class GroupServiceTest {
     private MemberService memberService;
 
     private AuthUser authUser;
+
+    private final static Integer CAMPUS_ID = 29;
+
     @BeforeEach
     public void setUp () {
         // Given
         Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
         authUser = new AuthUser(10000, "phan", 1L);
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(10000, "phan", "c1r1s1", "image", true, "2022-10-31", 29);
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(10000, "phan", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
         Hane hane = Hane.create("IN");
         memberService.createAgreeMember(cadetPrivacy, hane);
         createGroupDto = new CreateGroupDTO("popopop");

--- a/src/test/java/kr/where/backend/group/GroupServiceTest.java
+++ b/src/test/java/kr/where/backend/group/GroupServiceTest.java
@@ -42,7 +42,7 @@ public class GroupServiceTest {
         Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
         authUser = new AuthUser(10000, "phan", 1L);
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(10000, "phan", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(10000, "phan", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
         memberService.createAgreeMember(cadetPrivacy, hane);
         createGroupDto = new CreateGroupDTO("popopop");

--- a/src/test/java/kr/where/backend/location/LocationServiceTest.java
+++ b/src/test/java/kr/where/backend/location/LocationServiceTest.java
@@ -49,7 +49,7 @@ public class LocationServiceTest {
     @Test
     public void update_custom_location_test() {
 		//given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
 
         Member agreeMember = memberService.createAgreeMember(cadetPrivacy, hane);
@@ -74,7 +74,7 @@ public class LocationServiceTest {
     @Test
     public void delete_custom_location_test() {
         //given
-        CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
         Hane hane = Hane.create("IN");
 
         memberService.createAgreeMember(cadetPrivacy, hane);

--- a/src/test/java/kr/where/backend/member/memberServiceTest.java
+++ b/src/test/java/kr/where/backend/member/memberServiceTest.java
@@ -10,6 +10,7 @@ import kr.where.backend.group.entity.GroupMember;
 import kr.where.backend.location.Location;
 import kr.where.backend.location.LocationRepository;
 import kr.where.backend.location.LocationService;
+import kr.where.backend.member.dto.ResponseMemberDTO;
 import kr.where.backend.member.dto.UpdateMemberCommentDTO;
 
 import kr.where.backend.member.exception.MemberException;
@@ -52,14 +53,14 @@ public class memberServiceTest {
 	@BeforeEach
 	public void setUp() {
 		Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
-		authUser = new AuthUser(12345, "suhwpark", 1L);
+		authUser = new AuthUser(135436, "suhwpark", 1L);
 		SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
 	}
 	@Test
 	public void create_agree_member_test() {
 
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 
 		//when
@@ -72,7 +73,7 @@ public class memberServiceTest {
 		List<GroupMember> groupMembers = groupMemberRepository.findGroupMemberByGroup_GroupId(agreeMember.getDefaultGroupId());
 
 		//then
-		assertThat(agreeMember.getIntraId()).isEqualTo(12345L);
+		assertThat(agreeMember.getIntraId()).isEqualTo(135436L);
 		assertThat(agreeMember.getIntraName()).isEqualTo("suhwpark");
 		assertThat(agreeMember.getImage()).isEqualTo("image");
 		assertThat(agreeMember.getGrade()).isEqualTo("2022-10-31");
@@ -85,7 +86,7 @@ public class memberServiceTest {
 		assertThat(group.get().getGroupName()).isEqualTo("default");
 
 		assertThat(groupMembers).isNotNull();
-		assertThat(groupMembers.get(0).getMember().getIntraId()).isEqualTo(12345L);
+		assertThat(groupMembers.get(0).getMember().getIntraId()).isEqualTo(135436L);
 		assertThat(groupMembers.get(0).getIsOwner()).isEqualTo(true);
 
 	}
@@ -93,7 +94,7 @@ public class memberServiceTest {
 	@Test
 	public void create_disagree_member_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 
 		//when
 		Member disagreeMember = memberService.createDisagreeMember(cadetPrivacy);
@@ -103,7 +104,7 @@ public class memberServiceTest {
 		Location location = locationRepository.findByMember(member.get());
 
 		//then
-		assertThat(disagreeMember.getIntraId()).isEqualTo(12345L);
+		assertThat(disagreeMember.getIntraId()).isEqualTo(135436L);
 		assertThat(disagreeMember.getIntraName()).isEqualTo("suhwpark");
 		assertThat(disagreeMember.getImage()).isEqualTo("image");
 		assertThat(disagreeMember.getGrade()).isEqualTo("2022-10-31");
@@ -116,7 +117,7 @@ public class memberServiceTest {
 	@Test
 	public void disagree_to_agree_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		memberService.createDisagreeMember(cadetPrivacy);
 		Hane hane = Hane.create("IN");
 
@@ -130,7 +131,7 @@ public class memberServiceTest {
 		List<GroupMember> groupMembers = groupMemberRepository.findGroupMemberByGroup_GroupId(agreeMember.getDefaultGroupId());
 
 		//then
-		assertThat(agreeMember.getIntraId()).isEqualTo(12345L);
+		assertThat(agreeMember.getIntraId()).isEqualTo(135436L);
 		assertThat(agreeMember.getIntraName()).isEqualTo("suhwpark");
 		assertThat(agreeMember.getImage()).isEqualTo("image");
 		assertThat(agreeMember.getGrade()).isEqualTo("2022-10-31");
@@ -143,14 +144,14 @@ public class memberServiceTest {
 		assertThat(group.get().getGroupName()).isEqualTo("default");
 
 		assertThat(groupMembers).isNotNull();
-		assertThat(groupMembers.get(0).getMember().getIntraId()).isEqualTo(12345L);
+		assertThat(groupMembers.get(0).getMember().getIntraId()).isEqualTo(135436L);
 		assertThat(groupMembers.get(0).getIsOwner()).isEqualTo(true);
 	}
 
 	@Test
 	public void member_duplicate_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 
 		//when
@@ -164,7 +165,7 @@ public class memberServiceTest {
 	@Test
 	public void update_comment_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 		memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -186,7 +187,7 @@ public class memberServiceTest {
 	@Test
 	public void delete_comment_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 		memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -210,7 +211,7 @@ public class memberServiceTest {
 	public void invalidCampusId() throws MemberException {
 	    //given
 		CadetPrivacy cadetPrivacy = new CadetPrivacy(
-				12345, "suhwpark", "c1r1s1",
+				135436, "suhwpark", "c1r1s1",
 				"image", true, "2022-10-31", 30
 		);
 
@@ -223,11 +224,29 @@ public class memberServiceTest {
 	public void anotherCampusTryToCreateDisagreeMember() throws Exception {
 	    //given
 		CadetPrivacy cadetPrivacy = new CadetPrivacy(
-				12345, "suhwpark", "c1r1s1",
+				135436, "suhwpark", "c1r1s1",
 				"image", true, "2022-10-31", 30
 		);
 	    //then
 		assertThatThrownBy(() -> memberService.createDisagreeMember(cadetPrivacy))
 				.isInstanceOf(MemberException.NotFromSeoulCampus.class);
 	}
+
+	@Test
+	public void findOneByIntraId() {
+		//given
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "", "image", true, "2022-10-31", 29);
+		Hane hane = Hane.create("OUT");
+		Member createMember = memberService.createAgreeMember(cadetPrivacy, hane);
+
+		//when
+		ResponseMemberDTO findMember = memberService.findOneByIntraId(135436);
+
+		//then
+		assertThat(findMember.getIntraId()).isEqualTo(135436L);
+		assertThat(findMember.getIntraName()).isEqualTo("suhwpark");
+		assertThat(findMember.isInCluster()).isEqualTo(true);
+
+	}
+
 }

--- a/src/test/java/kr/where/backend/member/memberServiceTest.java
+++ b/src/test/java/kr/where/backend/member/memberServiceTest.java
@@ -44,8 +44,6 @@ public class memberServiceTest {
 	@Autowired
 	private LocationRepository locationRepository;
 	@Autowired
-	private LocationService locationService;
-	@Autowired
 	private GroupRepository groupRepository;
 	@Autowired
 	private GroupMemberRepository groupMemberRepository;
@@ -61,7 +59,7 @@ public class memberServiceTest {
 	public void create_agree_member_test() {
 
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 
 		//when
@@ -95,7 +93,7 @@ public class memberServiceTest {
 	@Test
 	public void create_disagree_member_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 
 		//when
 		Member disagreeMember = memberService.createDisagreeMember(cadetPrivacy);
@@ -118,7 +116,7 @@ public class memberServiceTest {
 	@Test
 	public void disagree_to_agree_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		memberService.createDisagreeMember(cadetPrivacy);
 		Hane hane = Hane.create("IN");
 
@@ -152,7 +150,7 @@ public class memberServiceTest {
 	@Test
 	public void member_duplicate_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 
 		//when
@@ -166,7 +164,7 @@ public class memberServiceTest {
 	@Test
 	public void update_comment_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 		memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -188,7 +186,7 @@ public class memberServiceTest {
 	@Test
 	public void delete_comment_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31");
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(12345, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
 		Hane hane = Hane.create("IN");
 		memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -206,5 +204,30 @@ public class memberServiceTest {
 		//then
 		assertThat(beforeComment).isEqualTo("new comment");
 		assertThat(afterComment).isEqualTo(null);
+	}
+
+	@Test
+	public void invalidCampusId() throws MemberException {
+	    //given
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(
+				12345, "suhwpark", "c1r1s1",
+				"image", true, "2022-10-31", 30
+		);
+
+		//then
+		assertThatThrownBy(() -> memberService.isSeoulCampus(cadetPrivacy))
+				.isInstanceOf(MemberException.NotFromSeoulCampus.class);
+	}
+
+	@Test
+	public void anotherCampusTryToCreateDisagreeMember() throws Exception {
+	    //given
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(
+				12345, "suhwpark", "c1r1s1",
+				"image", true, "2022-10-31", 30
+		);
+	    //then
+		assertThatThrownBy(() -> memberService.createDisagreeMember(cadetPrivacy))
+				.isInstanceOf(MemberException.NotFromSeoulCampus.class);
 	}
 }

--- a/src/test/java/kr/where/backend/member/memberServiceTest.java
+++ b/src/test/java/kr/where/backend/member/memberServiceTest.java
@@ -9,7 +9,6 @@ import kr.where.backend.group.entity.Group;
 import kr.where.backend.group.entity.GroupMember;
 import kr.where.backend.location.Location;
 import kr.where.backend.location.LocationRepository;
-import kr.where.backend.location.LocationService;
 import kr.where.backend.member.dto.ResponseMemberDTO;
 import kr.where.backend.member.dto.UpdateMemberCommentDTO;
 
@@ -50,6 +49,8 @@ public class memberServiceTest {
 	private GroupMemberRepository groupMemberRepository;
 	private AuthUser authUser;
 
+	private final static Integer CAMPUS_ID = 29;
+
 	@BeforeEach
 	public void setUp() {
 		Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
@@ -60,7 +61,7 @@ public class memberServiceTest {
 	public void create_agree_member_test() {
 
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
 		Hane hane = Hane.create("IN");
 
 		//when
@@ -94,7 +95,7 @@ public class memberServiceTest {
 	@Test
 	public void create_disagree_member_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
 
 		//when
 		Member disagreeMember = memberService.createDisagreeMember(cadetPrivacy);
@@ -117,7 +118,7 @@ public class memberServiceTest {
 	@Test
 	public void disagree_to_agree_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
 		memberService.createDisagreeMember(cadetPrivacy);
 		Hane hane = Hane.create("IN");
 
@@ -151,7 +152,7 @@ public class memberServiceTest {
 	@Test
 	public void member_duplicate_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
 		Hane hane = Hane.create("IN");
 
 		//when
@@ -165,7 +166,7 @@ public class memberServiceTest {
 	@Test
 	public void update_comment_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
 		Hane hane = Hane.create("IN");
 		memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -187,7 +188,7 @@ public class memberServiceTest {
 	@Test
 	public void delete_comment_test() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1", "image", true, "2022-10-31", CAMPUS_ID);
 		Hane hane = Hane.create("IN");
 		memberService.createAgreeMember(cadetPrivacy, hane);
 
@@ -235,7 +236,7 @@ public class memberServiceTest {
 	@Test
 	public void findOneByIntraId() {
 		//given
-		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "", "image", true, "2022-10-31", 29);
+		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "", "image", true, "2022-10-31", CAMPUS_ID);
 		Hane hane = Hane.create("OUT");
 		Member createMember = memberService.createAgreeMember(cadetPrivacy, hane);
 

--- a/src/test/java/kr/where/backend/member/memberServiceTest.java
+++ b/src/test/java/kr/where/backend/member/memberServiceTest.java
@@ -240,9 +240,13 @@ public class memberServiceTest {
 		Member createMember = memberService.createAgreeMember(cadetPrivacy, hane);
 
 		//when
+		createMember.setInClusterUpdatedAtForTest();
 		ResponseMemberDTO findMember = memberService.findOneByIntraId(135436);
+		Member member = memberRepository.findByIntraId(135436).orElse(null);
 
 		//then
+		System.out.println(createMember.getInClusterUpdatedAt());
+		System.out.println(member.getInClusterUpdatedAt());
 		assertThat(findMember.getIntraId()).isEqualTo(135436L);
 		assertThat(findMember.getIntraName()).isEqualTo("suhwpark");
 		assertThat(findMember.isInCluster()).isEqualTo(true);

--- a/src/test/java/kr/where/backend/member/memberServiceTest.java
+++ b/src/test/java/kr/where/backend/member/memberServiceTest.java
@@ -241,7 +241,7 @@ public class memberServiceTest {
 		Member createMember = memberService.createAgreeMember(cadetPrivacy, hane);
 
 		//when
-		createMember.setInClusterUpdatedAtForTest();
+		// createMember.setInClusterUpdatedAtForTest();
 		ResponseMemberDTO findMember = memberService.findOneByIntraId(135436);
 		Member member = memberRepository.findByIntraId(135436).orElse(null);
 


### PR DESCRIPTION
- 메인화면 조회 시 사용하는 API에서 hane 업데이트
> findGroupMemberByGroupId in GroupMemberService
> findOneByIntraId in MemberService
> 내에서 haneApiServiceService.updateInClusterOne(member) 호출
> inCluster가 update된지 3분 초과면 update

- member entity에 inClusterUpdatedAt 만들었습니다
- 서울 캠퍼스 소속 아니면 가입 불가 처리