### PR TITLE
256 가장 많이 사용하는 개인 imac 자리 구현 버그 수정

### DIFF
--- a/src/main/java/kr/where/backend/seatHistory/SeatHistory.java
+++ b/src/main/java/kr/where/backend/seatHistory/SeatHistory.java
@@ -24,7 +24,7 @@ public class SeatHistory {
     private LocalDateTime updateAt;
 
     @ManyToOne
-    @JoinColumn(name = "intra_id")
+    @JoinColumn(name = "member_id")
     private Member member;
 
     public SeatHistory(final String imac, final Member member) {

--- a/src/main/java/kr/where/backend/update/UpdateService.java
+++ b/src/main/java/kr/where/backend/update/UpdateService.java
@@ -130,7 +130,7 @@ public class UpdateService {
                 loginStatus.stream()
                         .filter(cluster -> cluster.getEnd_at() == null)
                         .forEach(cluster -> {
-                            seatHistoryService.report(cluster.getUser().getLocation(), cluster.getId());
+                            seatHistoryService.report(cluster.getUser().getLocation(), cluster.getUser().getId());
                             statusResult.add(cluster);
                         });
                 if (loginStatus.size() < 100) {

--- a/src/test/java/kr/where/backend/seatHistory/SeatHistoryTest.java
+++ b/src/test/java/kr/where/backend/seatHistory/SeatHistoryTest.java
@@ -142,4 +142,10 @@ public class SeatHistoryTest {
         assertThat(seatHistories.size()).isEqualTo(1);
         assertThat(seatHistories.get(0).getImac()).isEqualTo("c1r1s1");
     }
+
+    @Test
+    @DisplayName("자리 정보 추가시 잘못된 존재하지 intra_id를 저장하려고 할때 익센션 터지는 Test")
+    void saveInvalidIntraIdThrowsException() {
+        assertThrows(MemberException.NoMemberException.class, () -> seatHistoryService.report("c1r1s1", 99999999));
+    }
 }

--- a/src/test/java/kr/where/backend/seatHistory/SeatHistoryTest.java
+++ b/src/test/java/kr/where/backend/seatHistory/SeatHistoryTest.java
@@ -1,6 +1,5 @@
 package kr.where.backend.seatHistory;
 
-import com.fasterxml.classmate.MemberResolver;
 import kr.where.backend.api.json.CadetPrivacy;
 import kr.where.backend.api.json.hane.Hane;
 import kr.where.backend.auth.authUser.AuthUser;
@@ -15,22 +14,24 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
 @SpringBootTest
 @Transactional
 @Rollback
+@ActiveProfiles("test")
 public class SeatHistoryTest {
 
     @Autowired
@@ -81,6 +82,11 @@ public class SeatHistoryTest {
         assertThat(seatHistoryList.size()).isEqualTo(1);
     }
 
+    /**
+     * 주의사항:
+     * - 테스트는 SeatHistory::increaseCount 메서드가 항상 사용 횟수를 증가시키는 상태에서 실행되어야 한다.
+     * 5분 제한 조건이 없는 상태에서 테스트 수행하기 위해 SeatHistory::increaseCount함수에 `if (!isAfter5Minute()) {return}`을 주석처리 하고 실행한다.
+     */
     @Test
     @DisplayName("사용했던 자리면, 사용한 수를 증가하고 처음 앉는 자리라면 새로 만들어서 기록하는 test")
     void createOrIncreaseHistory() {
@@ -103,6 +109,11 @@ public class SeatHistoryTest {
         assertThat(seatHistory.getCount()).isEqualTo(2);
     }
 
+    /**
+     * 주의사항:
+     * - 테스트는 SeatHistory::increaseCount 메서드가 항상 사용 횟수를 증가시키는 상태에서 실행되어야 한다.
+     * 5분 제한 조건이 없는 상태에서 테스트 수행하기 위해 SeatHistory::increaseCount함수에 `if (!isAfter5Minute()) {return}`을 주석처리 하고 실행한다.
+     */
     @Test
     @DisplayName("가장 많이 사용하는 자리 3곳과 총 사용자리 대비 퍼센트 구하는 test")
     void getPopularSeatHistories() {


### PR DESCRIPTION
수정내용
1. seatHistoryService.report 함수의 인자 intra_id에 올바르지 않은 값이 들어가 NoMemberException이 발생하여 수정하였습니다.
2. seatHistory의 member column의 pk이름을 의미에 맞게 수정하였습니다.