### PR TITLE
[fix] : modify annotation

### DIFF
--- a/src/main/java/kr/where/backend/jwt/dto/RequestReissueDTO.java
+++ b/src/main/java/kr/where/backend/jwt/dto/RequestReissueDTO.java
@@ -1,11 +1,11 @@
 package kr.where.backend.jwt.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RequestReissueDTO {
-    @NotBlank
+    @NotNull
     private Integer intraId;
 }


### PR DESCRIPTION
NotBlank 어노테이션은 string에만 사용이 가능하여 에러발생했습니다.
NotNull 사용으로 변경하겠습니다.

```
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
public class RequestReissueDTO {
    @NotBlank
    private Integer intraId;
}
```