### PR TITLE
284 search시 redis에 저장되지 않는 에러 해결

### DIFF
--- a/src/main/java/kr/where/backend/cache/CacheService.java
+++ b/src/main/java/kr/where/backend/cache/CacheService.java
@@ -1,0 +1,43 @@
+package kr.where.backend.cache;
+
+import kr.where.backend.api.IntraApiService;
+import kr.where.backend.api.json.CadetPrivacy;
+import kr.where.backend.oauthtoken.OAuthTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CacheService {
+    final IntraApiService intraApiService;
+    final OAuthTokenService oauthTokenService;
+    private static final String TOKEN_NAME = "search";
+    private static final int MAXIMUM_SIZE = 10;
+
+    @Cacheable(key = "#word", value = "searchCache", cacheManager = "redisCacheManager", unless = "#result.isEmpty()")
+    public List<CadetPrivacy> getSearchCacheResult(final String word) {
+        final List<CadetPrivacy> result = new ArrayList<>();
+
+        int page = 1;
+        while (true) {
+            final List<CadetPrivacy> searchApiResult =
+                    intraApiService.getCadetsInRange(oauthTokenService.findAccessToken(TOKEN_NAME), word, page);
+
+            isActiveCadet(result, searchApiResult);
+            if (searchApiResult.size() < MAXIMUM_SIZE || result.size() > 14) {
+                break;
+            }
+            page += 1;
+        }
+
+        return result;
+    }
+
+    private void isActiveCadet(final List<CadetPrivacy> result, final List<CadetPrivacy> cadetPrivacies) {
+        cadetPrivacies.stream().filter(CadetPrivacy::isActive).forEach(result::add);
+    }
+}

--- a/src/main/java/kr/where/backend/search/SearchController.java
+++ b/src/main/java/kr/where/backend/search/SearchController.java
@@ -1,5 +1,7 @@
 package kr.where.backend.search;
 
+import kr.where.backend.aspect.LogLevel;
+import kr.where.backend.aspect.RequestLogging;
 import kr.where.backend.auth.authUser.AuthUser;
 import kr.where.backend.auth.authUser.AuthUserInfo;
 import kr.where.backend.search.dto.ResponseSearchDTO;
@@ -9,10 +11,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.logging.Level;
 
 @RestController
 @RequestMapping("/v3/search")
 @RequiredArgsConstructor
+@RequestLogging(level = LogLevel.INFO)
 public class SearchController implements SearchApiDocs {
 
     private final SearchService searchService;

--- a/src/main/java/kr/where/backend/search/SearchService.java
+++ b/src/main/java/kr/where/backend/search/SearchService.java
@@ -26,7 +26,7 @@ public class SearchService {
     private static final String PATTERN = "^[0-9a-z-]*$";
     private static final String TOKEN_NAME = "search";
     private static final int MAXIMUM_SIZE = 10;
-    private static final int MINIMUM_LENGTH = 3;
+    private static final int MINIMUM_LENGTH = 1;
     private static final int MAXIMUM_LENGTH = 10;
     private final MemberService memberService;
     private final IntraApiService intraApiService;

--- a/src/main/java/kr/where/backend/search/SearchService.java
+++ b/src/main/java/kr/where/backend/search/SearchService.java
@@ -7,6 +7,7 @@ import java.util.regex.Pattern;
 import kr.where.backend.api.IntraApiService;
 import kr.where.backend.api.json.CadetPrivacy;
 import kr.where.backend.auth.authUser.AuthUser;
+import kr.where.backend.cache.CacheService;
 import kr.where.backend.group.GroupRepository;
 import kr.where.backend.group.entity.Group;
 import kr.where.backend.group.exception.GroupException;
@@ -17,7 +18,6 @@ import kr.where.backend.search.dto.ResponseSearchDTO;
 import kr.where.backend.search.exception.SearchException;
 import kr.where.backend.oauthtoken.OAuthTokenService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,6 +32,7 @@ public class SearchService {
     private final IntraApiService intraApiService;
     private final OAuthTokenService oauthTokenService;
     private final GroupRepository groupRepository;
+    private final CacheService cacheService;
 
 
     /**
@@ -39,7 +40,6 @@ public class SearchService {
      * @return response로 변경하여 client 측에 전달 검색하고자 하는 입력값의 결과 10개를 반환 블랙홀에 빠지지 않은 카뎃을 필터로 걸러서 response DTO 생성
      * 입력 받은 값을 trim으로 공백을 없애주고, 대문자 영어가 들어와도 검색 가능하게 toLowerCase 적용
      */
-
     public List<ResponseSearchDTO> search(final String keyWord, final AuthUser authUser) {
         final String word = validateKeyWord(keyWord.trim().toLowerCase());
         final Member member = memberService.findOne(authUser.getIntraId())
@@ -52,7 +52,7 @@ public class SearchService {
         if (keyWord.isEmpty() || !isContainOnlyEnglishAndDigit(keyWord)) {
             throw new SearchException.InvalidContextException();
         }
-        if (!newValidateLength(keyWord)) {
+        if (!validateLength(keyWord)) {
             throw new SearchException.InvalidLengthException();
         }
         return keyWord;
@@ -64,10 +64,6 @@ public class SearchService {
 
     private boolean validateLength(final String keyWord) {
         return keyWord.length() > MINIMUM_LENGTH && keyWord.length() < MAXIMUM_LENGTH;
-    }
-
-    private boolean newValidateLength(final String keyWord) {
-        return keyWord.length() >= 3 && keyWord.length() <= MAXIMUM_LENGTH;
     }
 
     private List<CadetPrivacy> findActiveCadets(final String word) {
@@ -104,14 +100,20 @@ public class SearchService {
                 .toList();
     }
 
+    /**
+     * new api for search using redis caching
+     * @param keyWord
+     * @param authUser
+     * @return
+     */
     public List<ResponseSearchDTO> searchUser(final String keyWord, final AuthUser authUser) {
-        final String word = validateKeyWord(keyWord.trim().toLowerCase());
+        final String word = newValidateKeyWord(keyWord.trim().toLowerCase());
         final Member member = memberService.findOne(authUser.getIntraId())
                 .orElseThrow(MemberException.NoMemberException::new);
 
         final String cacheKey = word.substring(0, 3);
 
-        final List<CadetPrivacy> response = searchOnCache(cacheKey);
+        final List<CadetPrivacy> response = cacheService.getSearchCacheResult(cacheKey);
 
         if (Objects.equals(word, cacheKey)) {
             return responseOfSearch(member, response);
@@ -125,22 +127,17 @@ public class SearchService {
         );
     }
 
-    @Cacheable(key = "#word", value = "searchCache", cacheManager = "redisCacheManager", unless = "#result.isEmpty()")
-    public List<CadetPrivacy> searchOnCache(final String word) {
-        final List<CadetPrivacy> result = new ArrayList<>();
-
-        int page = 1;
-        while (true) {
-            final List<CadetPrivacy> searchApiResult =
-                    intraApiService.getCadetsInRange(oauthTokenService.findAccessToken(TOKEN_NAME), word, page);
-
-            isActiveCadet(result, searchApiResult);
-            if (searchApiResult.size() < MAXIMUM_SIZE || result.size() > 14) {
-                break;
-            }
-            page += 1;
+    private String newValidateKeyWord(final String keyWord) {
+        if (keyWord.isEmpty() || !isContainOnlyEnglishAndDigit(keyWord)) {
+            throw new SearchException.InvalidContextException();
         }
+        if (!newValidateLength(keyWord)) {
+            throw new SearchException.InvalidLengthException();
+        }
+        return keyWord;
+    }
 
-        return result;
+    private boolean newValidateLength(final String keyWord) {
+        return keyWord.length() >= 3 && keyWord.length() <= MAXIMUM_LENGTH;
     }
 }

--- a/src/test/java/kr/where/backend/search/SearchServiceTest.java
+++ b/src/test/java/kr/where/backend/search/SearchServiceTest.java
@@ -1,5 +1,6 @@
 package kr.where.backend.search;
 
+import kr.where.backend.cache.CacheService;
 import kr.where.backend.search.dto.ResponseSearchDTO;
 import org.mockito.Mockito;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,9 @@ public class SearchServiceTest {
 
     @MockBean
     OAuthTokenService oauthTokenService;
+
+    @Autowired
+    CacheService cacheService;
 
     AuthUser authUser;
 
@@ -102,8 +106,7 @@ public class SearchServiceTest {
         when(intraApiService.getCadetsInRange("testToken", "soo", 1)).thenReturn(cadetPrivacies);
 
         //when
-        searchService.searchOnCache("soo");
-        List<CadetPrivacy> response = searchService.searchOnCache("soo");
+        List<CadetPrivacy> response = cacheService.getSearchCacheResult("soo");
 
         //then
         //getCadetsInRange 메서드가 한번 호출되었는지 확인
@@ -137,7 +140,7 @@ public class SearchServiceTest {
         when(oauthTokenService.findAccessToken("search")).thenReturn("testToken");
         when(intraApiService.getCadetsInRange("testToken", "soo", 1)).thenReturn(cadetPrivacies);
 
-        searchService.searchOnCache("soo");
+        cacheService.getSearchCacheResult("soo");
         //when
         List<ResponseSearchDTO> responses = searchService.searchUser("sooh", authUser);
 


### PR DESCRIPTION
## cacheService를 선언하여, cache가 있으면, cache 값을 사용 없으면 42api 요청하여 캐시에 저장 후 사용
```java
    @Cacheable(key = "#word", value = "searchCache", cacheManager = "redisCacheManager", unless = "#result.isEmpty()")
    public List<CadetPrivacy> getSearchCacheResult(final String word) {
        final List<CadetPrivacy> result = new ArrayList<>();

        int page = 1;
        while (true) {
            final List<CadetPrivacy> searchApiResult =
                    intraApiService.getCadetsInRange(oauthTokenService.findAccessToken(TOKEN_NAME), word, page);

            isActiveCadet(result, searchApiResult);
            if (searchApiResult.size() < MAXIMUM_SIZE || result.size() > 14) {
                break;
            }
            page += 1;
        }

        return result;
    }
```

- searchService는 키워드 파싱, 결과값 dto 매핑, 세글자 이상의 keyword에 대한 기대값을 dto로 매핑의 역할만 한다
- cacheService는 캐시값 get, 없다면 42api 요청 후 저장의 역할만한다