### PR TITLE
286 imac history를 주기적으로 통계 데이터로 저장하는 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     testImplementation 'junit:junit:4.13.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.testcontainers:testcontainers:1.20.4'
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
     testImplementation 'org.projectlombok:lombok:1.18.26'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -59,4 +62,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //json
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
 }

--- a/src/main/java/kr/where/backend/analytics/AnalyticsController.java
+++ b/src/main/java/kr/where/backend/analytics/AnalyticsController.java
@@ -1,10 +1,11 @@
 package kr.where.backend.analytics;
 
-import kr.where.backend.analytics.dto.ResponsePopularImacListDTO;
-import kr.where.backend.analytics.dto.ResponseSeatHistoryListDTO;
+import kr.where.backend.analytics.dto.ResponseAnalyticsDTO;
 import kr.where.backend.analytics.swagger.AnalyticsApiDocs;
 import kr.where.backend.aspect.LogLevel;
 import kr.where.backend.aspect.RequestLogging;
+import kr.where.backend.auth.authUser.AuthUser;
+import kr.where.backend.auth.authUser.AuthUserInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,16 +18,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestLogging(level = LogLevel.INFO)
 @RequestMapping("v3/analytics")
 public class AnalyticsController implements AnalyticsApiDocs {
+    private final AnalyticsService analyticsService;
 
     @Override
     @GetMapping("/seat-history")
-    public ResponseEntity<ResponseSeatHistoryListDTO> getMemberSeatHistory(@RequestParam("count") final Integer count) {
-        return null;
+    public ResponseEntity<ResponseAnalyticsDTO> getMemberSeatHistory(@AuthUserInfo final AuthUser authUser,
+                                                                     @RequestParam("count") final Integer count) {
+        return ResponseEntity.ok(
+                analyticsService.getMemberImacUsageAnalyticsData(authUser.getIntraId(), count)
+        );
     }
 
     @Override
     @GetMapping("/popular-imac")
-    public ResponseEntity<ResponsePopularImacListDTO> getPopularImac(@RequestParam("count") final Integer count) {
-        return null;
+    public ResponseEntity<ResponseAnalyticsDTO> getPopularImac(@AuthUserInfo final AuthUser authUser,
+                                                               @RequestParam("count") final Integer count) {
+        return ResponseEntity.ok(
+                analyticsService.getImacUsageAnalyticsData(count)
+        );
     }
 }

--- a/src/main/java/kr/where/backend/analytics/AnalyticsService.java
+++ b/src/main/java/kr/where/backend/analytics/AnalyticsService.java
@@ -1,0 +1,53 @@
+package kr.where.backend.analytics;
+
+import kr.where.backend.analytics.cache.AnalyticsCacheService;
+import kr.where.backend.analytics.dto.ResponseAnalyticsDTO;
+import kr.where.backend.analytics.dto.ResponseImacUsageAnalyticsDTO;
+import kr.where.backend.analytics.dto.ResponseMemberImacUsageAnalyticsDTO;
+import kr.where.backend.analytics.imacUsageAnalytics.ImacUsageAnalyticsRepository;
+import kr.where.backend.analytics.imacUsageAnalytics.ImacUsageAnalyticsView;
+import kr.where.backend.analytics.memberImacUsageAnalytics.MemberImacUsageAnalyticsRepository;
+import kr.where.backend.analytics.memberImacUsageAnalytics.MemberImacUsageAnalyticsView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnalyticsService {
+    final MemberImacUsageAnalyticsRepository memberImacUsageAnalyticsRepository;
+    final ImacUsageAnalyticsRepository imacUsageAnalyticsRepository;
+    final AnalyticsCacheService analyticsCacheService;
+
+    public ResponseAnalyticsDTO getMemberImacUsageAnalyticsData(final Integer intraId, final Integer count) {
+        final List<MemberImacUsageAnalyticsView> cacheData = analyticsCacheService.getMemberImacUsageAnalyticsCacheData(intraId);
+
+        return new ResponseAnalyticsDTO(cacheData.stream()
+                .limit(count)
+                .map(cache -> new ResponseMemberImacUsageAnalyticsDTO(
+                        cache.getImac(),
+                        cache.getUsageTime(),
+                        cache.getUsageCount()
+                        )
+                )
+                .toList()
+        );
+    }
+
+    public ResponseAnalyticsDTO getImacUsageAnalyticsData(final Integer count) {
+        final List<ImacUsageAnalyticsView> cacheData = analyticsCacheService.getImacUsageAnalyticsCacheData();
+
+        return new ResponseAnalyticsDTO(cacheData.stream()
+                .limit(count)
+                .map(cache -> new ResponseImacUsageAnalyticsDTO(
+                        cache.getImac(),
+                        cache.getUsageTime(),
+                        cache.getUsageCount()
+                        )
+                )
+                .toList()
+        );
+    }
+}

--- a/src/main/java/kr/where/backend/analytics/cache/AnalyticsCacheService.java
+++ b/src/main/java/kr/where/backend/analytics/cache/AnalyticsCacheService.java
@@ -1,0 +1,30 @@
+package kr.where.backend.analytics.cache;
+
+import kr.where.backend.analytics.imacUsageAnalytics.ImacUsageAnalyticsRepository;
+import kr.where.backend.analytics.imacUsageAnalytics.ImacUsageAnalyticsView;
+import kr.where.backend.analytics.memberImacUsageAnalytics.MemberImacUsageAnalyticsRepository;
+import kr.where.backend.analytics.memberImacUsageAnalytics.MemberImacUsageAnalyticsView;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalyticsCacheService {
+    private final MemberImacUsageAnalyticsRepository memberImacUsageAnalyticsRepository;
+    private final ImacUsageAnalyticsRepository imacUsageAnalyticsRepository;
+
+    @Cacheable(key = "#intraId", value = "analyticsCache", cacheManager = "redisCacheManager", unless = "#result.isEmpty()")
+    public List<MemberImacUsageAnalyticsView> getMemberImacUsageAnalyticsCacheData(final Integer intraId) {
+        return memberImacUsageAnalyticsRepository.findAllBy(intraId);
+    }
+
+    @Cacheable(key = "'imacHistory'", value = "analyticsCache", cacheManager = "redisCacheManager", unless = "#result.isEmpty()")
+    public List<ImacUsageAnalyticsView> getImacUsageAnalyticsCacheData() {
+        return imacUsageAnalyticsRepository.findAllOrOrderByUsageCount();
+    }
+}

--- a/src/main/java/kr/where/backend/analytics/dto/ResponseAnalyticsAbstract.java
+++ b/src/main/java/kr/where/backend/analytics/dto/ResponseAnalyticsAbstract.java
@@ -1,0 +1,21 @@
+package kr.where.backend.analytics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class ResponseAnalyticsAbstract {
+    protected String seat;
+    protected Long usingTimeHour;
+    protected Long usingTimeMinute;
+    protected Long usingTimeSecond;
+
+    public ResponseAnalyticsAbstract(final String seat, final Long usageTime) {
+        this.seat = seat;
+        this.usingTimeHour = usageTime / 3600; // 1시간 = 3600초
+        this.usingTimeMinute = (usageTime % 3600) / 60; // 남은 초에서 분 계산
+        this.usingTimeSecond = (usageTime) % 60; // 남은 초 계산
+    }
+}

--- a/src/main/java/kr/where/backend/analytics/dto/ResponseAnalyticsDTO.java
+++ b/src/main/java/kr/where/backend/analytics/dto/ResponseAnalyticsDTO.java
@@ -1,0 +1,17 @@
+package kr.where.backend.analytics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseAnalyticsDTO {
+    private List<?> seats;
+
+    public ResponseAnalyticsDTO(final List<?> seats) {
+        this.seats = seats;
+    }
+}

--- a/src/main/java/kr/where/backend/analytics/dto/ResponseImacUsageAnalyticsDTO.java
+++ b/src/main/java/kr/where/backend/analytics/dto/ResponseImacUsageAnalyticsDTO.java
@@ -1,0 +1,16 @@
+package kr.where.backend.analytics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseImacUsageAnalyticsDTO extends ResponseAnalyticsAbstract {
+    private Long usingUserCount;
+
+    public ResponseImacUsageAnalyticsDTO(final String imac, final Long usageTime, final Long usageCount) {
+        super(imac, usageTime);
+        this.usingUserCount = usageCount;
+    }
+}

--- a/src/main/java/kr/where/backend/analytics/dto/ResponseMemberImacUsageAnalyticsDTO.java
+++ b/src/main/java/kr/where/backend/analytics/dto/ResponseMemberImacUsageAnalyticsDTO.java
@@ -1,0 +1,16 @@
+package kr.where.backend.analytics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseMemberImacUsageAnalyticsDTO extends ResponseAnalyticsAbstract {
+    private Long usingCount;
+
+    public ResponseMemberImacUsageAnalyticsDTO(final String imac, final Long usageTime, final Long usageCount) {
+        super(imac, usageTime);
+        this.usingCount = usageCount;
+    }
+}

--- a/src/main/java/kr/where/backend/analytics/imacUsageAnalytics/ImacUsageAnalyticsRepository.java
+++ b/src/main/java/kr/where/backend/analytics/imacUsageAnalytics/ImacUsageAnalyticsRepository.java
@@ -1,0 +1,13 @@
+package kr.where.backend.analytics.imacUsageAnalytics;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ImacUsageAnalyticsRepository extends JpaRepository<ImacUsageAnalyticsView, Long> {
+    @Query("SELECT imacData FROM ImacUsageAnalyticsView imacData ORDER BY imacData.usageCount DESC")
+    List<ImacUsageAnalyticsView> findAllOrOrderByUsageCount();
+}

--- a/src/main/java/kr/where/backend/analytics/imacUsageAnalytics/ImacUsageAnalyticsView.java
+++ b/src/main/java/kr/where/backend/analytics/imacUsageAnalytics/ImacUsageAnalyticsView.java
@@ -1,0 +1,32 @@
+package kr.where.backend.analytics.imacUsageAnalytics;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Subselect;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Immutable
+@Subselect("SELECT ROW_NUMBER() OVER (ORDER BY imac) AS id, " +
+        "imac," +
+        "CAST(SUM(EXTRACT(EPOCH FROM logout_at - login_at)) AS BIGINT) AS usage_time, " +
+        "COUNT(imac) as usage_count, " +
+        "MIN(login_at) as login_at_first, " +
+        "MAX(logout_at) as logout_at_last " +
+        "FROM imac_history " +
+        "WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '7' DAY " +
+        "GROUP BY imac"
+)
+@Table(name = "imac_usage_analytics_view")
+@Getter
+public class ImacUsageAnalyticsView {
+    @Id
+    private Long id;
+    private String imac;
+    private Long usageTime;
+    private Long usageCount;
+    private LocalDateTime loginAtFirst;
+    private LocalDateTime logoutAtLast;
+}

--- a/src/main/java/kr/where/backend/analytics/memberImacUsageAnalytics/MemberImacUsageAnalyticsRepository.java
+++ b/src/main/java/kr/where/backend/analytics/memberImacUsageAnalytics/MemberImacUsageAnalyticsRepository.java
@@ -1,0 +1,15 @@
+package kr.where.backend.analytics.memberImacUsageAnalytics;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MemberImacUsageAnalyticsRepository extends JpaRepository<MemberImacUsageAnalyticsView, Long> {
+    @Query("SELECT memberImacData FROM MemberImacUsageAnalyticsView memberImacData " +
+            "WHERE memberImacData.intraId =:intraId ORDER BY memberImacData.usageCount DESC")
+    List<MemberImacUsageAnalyticsView> findAllBy(@Param(value = "intraId") final Integer intraId);
+}

--- a/src/main/java/kr/where/backend/analytics/memberImacUsageAnalytics/MemberImacUsageAnalyticsView.java
+++ b/src/main/java/kr/where/backend/analytics/memberImacUsageAnalytics/MemberImacUsageAnalyticsView.java
@@ -1,0 +1,49 @@
+package kr.where.backend.analytics.memberImacUsageAnalytics;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Subselect;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Immutable
+@Subselect("SELECT ROW_NUMBER() OVER (ORDER BY imac) AS id, " +
+        "intra_id, " +
+        "imac, " +
+        "CAST(SUM(EXTRACT(EPOCH FROM logout_at - login_at)) AS BIGINT) AS usage_time, " +
+        "COUNT(*) AS usage_count, " +
+        "MIN(login_at) AS login_at_first, " +
+        "MAX(logout_at) AS logout_at_last " +
+        "FROM imac_history " +
+        "WHERE created_at >= CURRENT_TIMESTAMP - INTERVAL '7' DAY " +
+        "GROUP BY imac, intra_id")
+@Table(name = "member_imac_usage_analytics_view")
+@Getter
+@ToString
+public class MemberImacUsageAnalyticsView {
+    @Id
+    private Long id;
+
+    private Integer intraId;
+
+    private String imac;
+
+    private Long usageTime;
+
+    private Long usageCount;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime loginAtFirst;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    private LocalDateTime logoutAtLast;
+}

--- a/src/main/java/kr/where/backend/analytics/swagger/AnalyticsApiDocs.java
+++ b/src/main/java/kr/where/backend/analytics/swagger/AnalyticsApiDocs.java
@@ -7,8 +7,9 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import kr.where.backend.analytics.dto.ResponsePopularImacListDTO;
-import kr.where.backend.analytics.dto.ResponseSeatHistoryListDTO;
+import kr.where.backend.analytics.dto.ResponseAnalyticsDTO;
+import kr.where.backend.auth.authUser.AuthUser;
+import kr.where.backend.auth.authUser.AuthUserInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,11 +24,12 @@ public interface AnalyticsApiDocs {
                     @Parameter(name = "count", description = "반환 받고 싶은 자리 갯수 (default = 1)", in = ParameterIn.QUERY)
             },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ResponseSeatHistoryListDTO.class)))
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ResponseAnalyticsDTO.class)))
             }
     )
     @GetMapping("/seat-history")
-    ResponseEntity<ResponseSeatHistoryListDTO> getMemberSeatHistory(@RequestParam("count") final Integer count);
+    ResponseEntity<ResponseAnalyticsDTO> getMemberSeatHistory(@AuthUserInfo final AuthUser authUser,
+                                                              @RequestParam("count") final Integer count);
 
 
     @Operation(
@@ -37,9 +39,10 @@ public interface AnalyticsApiDocs {
                     @Parameter(name = "count", description = "반환 받고 싶은 아이맥 갯수 (default = 5)", in = ParameterIn.QUERY)
             },
             responses = {
-                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ResponseSeatHistoryListDTO.class)))
+                    @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = ResponseAnalyticsDTO.class)))
             }
     )
     @GetMapping("/popular-imac")
-    ResponseEntity<ResponsePopularImacListDTO> getPopularImac(@RequestParam("count") final Integer count);
+    ResponseEntity<ResponseAnalyticsDTO> getPopularImac(@AuthUserInfo final AuthUser authUser,
+                                                        @RequestParam("count") final Integer count);
 }

--- a/src/main/java/kr/where/backend/search/SearchService.java
+++ b/src/main/java/kr/where/backend/search/SearchService.java
@@ -7,7 +7,7 @@ import java.util.regex.Pattern;
 import kr.where.backend.api.IntraApiService;
 import kr.where.backend.api.json.CadetPrivacy;
 import kr.where.backend.auth.authUser.AuthUser;
-import kr.where.backend.cache.CacheService;
+import kr.where.backend.search.cache.SearchCacheService;
 import kr.where.backend.group.GroupRepository;
 import kr.where.backend.group.entity.Group;
 import kr.where.backend.group.exception.GroupException;
@@ -32,7 +32,7 @@ public class SearchService {
     private final IntraApiService intraApiService;
     private final OAuthTokenService oauthTokenService;
     private final GroupRepository groupRepository;
-    private final CacheService cacheService;
+    private final SearchCacheService searchCacheService;
 
 
     /**
@@ -113,7 +113,7 @@ public class SearchService {
 
         final String cacheKey = word.substring(0, 3);
 
-        final List<CadetPrivacy> response = cacheService.getSearchCacheResult(cacheKey);
+        final List<CadetPrivacy> response = searchCacheService.getSearchCacheResult(cacheKey);
 
         if (Objects.equals(word, cacheKey)) {
             return responseOfSearch(member, response);

--- a/src/main/java/kr/where/backend/search/cache/SearchCacheService.java
+++ b/src/main/java/kr/where/backend/search/cache/SearchCacheService.java
@@ -1,4 +1,4 @@
-package kr.where.backend.cache;
+package kr.where.backend.search.cache;
 
 import kr.where.backend.api.IntraApiService;
 import kr.where.backend.api.json.CadetPrivacy;
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class CacheService {
+public class SearchCacheService {
     final IntraApiService intraApiService;
     final OAuthTokenService oauthTokenService;
     private static final String TOKEN_NAME = "search";

--- a/src/test/java/kr/where/backend/analytics/AnalyticsRepositoryTest.java
+++ b/src/test/java/kr/where/backend/analytics/AnalyticsRepositoryTest.java
@@ -1,0 +1,169 @@
+package kr.where.backend.analytics;
+
+import kr.where.backend.analytics.imacUsageAnalytics.ImacUsageAnalyticsRepository;
+import kr.where.backend.analytics.imacUsageAnalytics.ImacUsageAnalyticsView;
+import kr.where.backend.analytics.memberImacUsageAnalytics.MemberImacUsageAnalyticsRepository;
+import kr.where.backend.analytics.memberImacUsageAnalytics.MemberImacUsageAnalyticsView;
+import kr.where.backend.api.json.CadetPrivacy;
+import kr.where.backend.api.json.hane.Hane;
+import kr.where.backend.auth.authUser.AuthUser;
+import kr.where.backend.imacHistory.ImacHistory;
+import kr.where.backend.imacHistory.ImacHistoryRepository;
+import kr.where.backend.member.Member;
+import kr.where.backend.member.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+@SpringBootTest
+@Transactional
+@Rollback
+public class AnalyticsRepositoryTest {
+    @Autowired
+    MemberImacUsageAnalyticsRepository memberImacUsageAnalyticsRepository;
+
+    @Autowired
+    ImacUsageAnalyticsRepository imacUsageAnalyticsRepository;
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    ImacHistoryRepository imacHistoryRepository;
+
+    Integer CAMPUS_ID = 29;
+    AuthUser authUser;
+
+    @BeforeEach
+    public void setUp() {
+        Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
+        authUser = new AuthUser(135436, "suhwpark", 1L);
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
+    }
+
+
+    @Test
+    @DisplayName("member 별 imac 사용 자리에 대한 view 테이블 생성 테스트")
+    void memberImacUsageViewRepositoryTest() throws Exception {
+        //given
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1",
+                "image", true, "2022-10-31", CAMPUS_ID);
+        Hane hane = Hane.create("IN");
+        Member member = memberService.createAgreeMember(cadetPrivacy, hane);
+        Integer intraId= member.getIntraId();
+
+        LocalDateTime present = LocalDateTime.now();
+        LocalDateTime after3Hour = present.plusHours(3);
+        String[] utcTimes = getUtcTimeString(present, after3Hour);
+
+        List<ImacHistory> imacHistories = List.of(
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c5r8s8", utcTimes[0], utcTimes[1]),
+                new ImacHistory(12345, "c5r8s8", utcTimes[0], utcTimes[1])
+        );
+        imacHistoryRepository.saveAll(imacHistories);
+
+        //when
+        List<MemberImacUsageAnalyticsView> memberImacUsageAnalyticsViewsIntraId =
+                memberImacUsageAnalyticsRepository.findAllBy(intraId);
+        List<MemberImacUsageAnalyticsView> memberImacUsageAnalyticsViews12345 =
+                memberImacUsageAnalyticsRepository.findAllBy(12345);
+        //then
+        assertThat(memberImacUsageAnalyticsViewsIntraId.size()).isEqualTo(3);
+        for (int i = 0; i < 3; ++i) {
+            MemberImacUsageAnalyticsView data = memberImacUsageAnalyticsViewsIntraId.get(i);
+            if (data.getImac().equals("c1r1s1")) {
+                assertThat(data.getUsageTime()).isEqualTo(32400L);
+                assertThat(data.getUsageCount()).isEqualTo(3);
+            }
+            if (data.getImac().equals("cx1r2s4")) {
+                assertThat(data.getUsageTime()).isEqualTo(21600L);
+                assertThat(data.getUsageCount()).isEqualTo(2);
+            }
+            if (data.getImac().equals("c5r8s8")) {
+                assertThat(data.getUsageTime()).isEqualTo(10800L);
+                assertThat(data.getUsageCount()).isEqualTo(1);
+            }
+        }
+
+        assertThat(memberImacUsageAnalyticsViews12345.size()).isEqualTo(1);
+        assertThat(memberImacUsageAnalyticsViews12345.get(0).getImac()).isEqualTo("c5r8s8");
+        assertThat(memberImacUsageAnalyticsViews12345.get(0).getUsageTime()).isEqualTo(10800L);
+        assertThat(memberImacUsageAnalyticsViews12345.get(0).getUsageCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("imac 자리별 사용에 대한 view 테이블 생성 test")
+    void imacUsageViewRepositoryTest() throws Exception {
+        //given
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1",
+                "image", true, "2022-10-31", CAMPUS_ID);
+        Hane hane = Hane.create("IN");
+        Member member = memberService.createAgreeMember(cadetPrivacy, hane);
+        Integer intraId= member.getIntraId();
+
+        LocalDateTime present = LocalDateTime.now();
+        LocalDateTime after3Hour = present.plusHours(3);
+        String[] utcTimes = getUtcTimeString(present, after3Hour);
+
+        List<ImacHistory> imacHistories = List.of(
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c5r8s8", utcTimes[0], utcTimes[1]),
+                new ImacHistory(12345, "c5r8s8", utcTimes[0], utcTimes[1])
+        );
+        imacHistoryRepository.saveAll(imacHistories);
+
+        //when
+        List<ImacUsageAnalyticsView> imacUsageAnalyticsViews = imacUsageAnalyticsRepository.findAll();
+
+        //then
+        assertThat(imacUsageAnalyticsViews.size()).isEqualTo(3);
+        for (int i = 0; i < 3; ++i) {
+            ImacUsageAnalyticsView data = imacUsageAnalyticsViews.get(i);
+            if (data.getImac().equals("c1r1s1")) {
+                assertThat(data.getUsageTime()).isEqualTo(32400L);
+                assertThat(data.getUsageCount()).isEqualTo(3);
+            }
+            if (data.getImac().equals("cx1r2s4")) {
+                assertThat(data.getUsageTime()).isEqualTo(21600L);
+                assertThat(data.getUsageCount()).isEqualTo(2);
+            }
+            if (data.getImac().equals("c5r8s8")) {
+                assertThat(data.getUsageTime()).isEqualTo(21600L);
+                assertThat(data.getUsageCount()).isEqualTo(2);
+            }
+        }
+    }
+    private String[] getUtcTimeString(LocalDateTime start, LocalDateTime end) {
+        DateTimeFormatter utcFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        String loginUtc = start.atZone(ZoneId.of("Asia/Seoul")).withZoneSameInstant(ZoneOffset.UTC).format(utcFormatter);
+        String logoutUtc = end.atZone(ZoneId.of("Asia/Seoul")).withZoneSameInstant(ZoneOffset.UTC).format(utcFormatter);
+
+        return new String[]{loginUtc, logoutUtc};
+    }
+}

--- a/src/test/java/kr/where/backend/analytics/AnalyticsServiceTest.java
+++ b/src/test/java/kr/where/backend/analytics/AnalyticsServiceTest.java
@@ -1,0 +1,160 @@
+package kr.where.backend.analytics;
+
+import kr.where.backend.analytics.dto.ResponseAnalyticsDTO;
+import kr.where.backend.analytics.dto.ResponseImacUsageAnalyticsDTO;
+import kr.where.backend.analytics.dto.ResponseMemberImacUsageAnalyticsDTO;
+import kr.where.backend.api.json.CadetPrivacy;
+import kr.where.backend.api.json.hane.Hane;
+import kr.where.backend.auth.authUser.AuthUser;
+import kr.where.backend.config.TestRedisContainer;
+import kr.where.backend.imacHistory.ImacHistory;
+import kr.where.backend.imacHistory.ImacHistoryRepository;
+import kr.where.backend.member.Member;
+import kr.where.backend.member.MemberService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+
+@SpringBootTest
+@Transactional
+@Rollback
+public class AnalyticsServiceTest {
+    @Autowired
+    ImacHistoryRepository imacHistoryRepository;
+
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    AnalyticsService analyticsService;
+
+    @Autowired
+    RedisTemplate<String, Object> template;
+
+    static final TestRedisContainer TEST_REDIS_CONTAINER = new TestRedisContainer();
+    Integer CAMPUS_ID = 29;
+    AuthUser authUser;
+
+    @BeforeAll
+    public static void setContainer() {
+        TEST_REDIS_CONTAINER.beforeAll();
+    }
+
+    @BeforeEach
+    void setUp() {
+        Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
+        authUser = new AuthUser(135436, "suhwpark", 1L);
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
+    }
+
+    @AfterEach
+    void flushRedis() {
+        Objects.requireNonNull(template.getConnectionFactory()).getConnection().serverCommands().flushDb();
+    }
+
+    @Test
+    @DisplayName("redis를 사용하여, member imac usage view table cache 존재시 cache 값 사용, 그렇지 않은 경우 생성 Test")
+    void memberImacUsageAnalyticsServiceTest() throws Exception {
+        //given
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1",
+                "image", true, "2022-10-31", CAMPUS_ID);
+        Hane hane = Hane.create("IN");
+        Member member = memberService.createAgreeMember(cadetPrivacy, hane);
+        Integer intraId= member.getIntraId();
+
+        LocalDateTime present = LocalDateTime.now();
+        LocalDateTime after3Hour = present.plusHours(3);
+        String[] utcTimes = getUtcTimeString(present, after3Hour);
+
+        List<ImacHistory> imacHistories = List.of(
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c5r8s8", utcTimes[0], utcTimes[1]),
+                new ImacHistory(12345, "c5r8s8", utcTimes[0], utcTimes[1])
+        );
+        imacHistoryRepository.saveAll(imacHistories);
+
+        //when
+        ResponseAnalyticsDTO result = analyticsService.getMemberImacUsageAnalyticsData(intraId, 1);
+
+        //then
+        assertThat(result.getSeats().size()).isEqualTo(1);
+
+        ResponseMemberImacUsageAnalyticsDTO dto = (ResponseMemberImacUsageAnalyticsDTO) result.getSeats().get(0);
+        assertThat(dto.getUsingCount()).isEqualTo(3);
+        assertThat(dto.getSeat()).isEqualTo("c1r1s1");
+        assertThat(dto.getUsingTimeHour()).isEqualTo(9);
+        assertThat(dto.getUsingTimeMinute()).isEqualTo(0);
+        assertThat(dto.getUsingTimeSecond()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("redis를 사용하여, imac usage view table cache 존재시 cache 값 사용, 그렇지 않은 경우 생성 Test")
+    void imacUsageAnalyticsServiceTest() throws Exception {
+        //given
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "c1r1s1",
+                "image", true, "2022-10-31", CAMPUS_ID);
+        Hane hane = Hane.create("IN");
+        Member member = memberService.createAgreeMember(cadetPrivacy, hane);
+        Integer intraId= member.getIntraId();
+
+        LocalDateTime present = LocalDateTime.now();
+        LocalDateTime after3Hour = present.plusHours(3);
+        String[] utcTimes = getUtcTimeString(present, after3Hour);
+
+        List<ImacHistory> imacHistories = List.of(
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c1r1s1", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "cx1r2s4", utcTimes[0], utcTimes[1]),
+                new ImacHistory(intraId, "c5r8s8", utcTimes[0], utcTimes[1]),
+                new ImacHistory(12345, "c5r8s8", utcTimes[0], utcTimes[1])
+        );
+        imacHistoryRepository.saveAll(imacHistories);
+
+        //when
+        ResponseAnalyticsDTO result = analyticsService.getImacUsageAnalyticsData(1);
+
+        //then
+        assertThat(result.getSeats().size()).isEqualTo(1);
+
+        ResponseImacUsageAnalyticsDTO dto = (ResponseImacUsageAnalyticsDTO) result.getSeats().get(0);
+        assertThat(dto.getUsingUserCount()).isEqualTo(3);
+        assertThat(dto.getSeat()).isEqualTo("c1r1s1");
+        assertThat(dto.getUsingTimeHour()).isEqualTo(9);
+        assertThat(dto.getUsingTimeMinute()).isEqualTo(0);
+        assertThat(dto.getUsingTimeSecond()).isEqualTo(0);
+
+    }
+
+
+    private String[] getUtcTimeString(LocalDateTime start, LocalDateTime end) {
+        DateTimeFormatter utcFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        String loginUtc = start.atZone(ZoneId.of("Asia/Seoul")).withZoneSameInstant(ZoneOffset.UTC).format(utcFormatter);
+        String logoutUtc = end.atZone(ZoneId.of("Asia/Seoul")).withZoneSameInstant(ZoneOffset.UTC).format(utcFormatter);
+
+        return new String[]{loginUtc, logoutUtc};
+    }
+}

--- a/src/test/java/kr/where/backend/config/TestRedisContainer.java
+++ b/src/test/java/kr/where/backend/config/TestRedisContainer.java
@@ -1,0 +1,16 @@
+package kr.where.backend.config;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+public class TestRedisContainer {
+    public void beforeAll() {
+        GenericContainer redis = new GenericContainer(DockerImageName.parse("redis:6-alpine"))
+                .withExposedPorts(6379);
+        redis.start();
+        System.setProperty("spring.data.redis.host", redis.getHost());
+        System.setProperty("spring.data.redis.port", String.valueOf(redis.getMappedPort(6379)));
+    }
+}

--- a/src/test/java/kr/where/backend/search/ApiTestUsingSearchServiceTest.java
+++ b/src/test/java/kr/where/backend/search/ApiTestUsingSearchServiceTest.java
@@ -1,13 +1,7 @@
 package kr.where.backend.search;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.where.backend.api.IntraApiService;
-import kr.where.backend.api.json.CadetPrivacy;
-import kr.where.backend.api.json.Image;
-import kr.where.backend.api.json.Versions;
 import kr.where.backend.auth.authUser.AuthUser;
-import kr.where.backend.group.entity.Group;
-import kr.where.backend.oauthtoken.OAuthTokenService;
 import kr.where.backend.search.dto.ResponseSearchDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +23,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;


### PR DESCRIPTION
- view table 생성 (SQL을 사용하지 않고, subselect을 사용하여, view접근 시 설정 쿼리 사용)
- redisconfig -> localDateTime serializer, deserializer 위한 변경
- test container 사용
- view 관련 repository 설정
- 통계 자료 보여주는 analyticsController, analyticsService 구현