### PR TITLE
유저가-아이맥에-로그인중인-상태로-외출을-하고-오면-현재자리가-null이-되는-문제

### DIFF
--- a/src/main/java/kr/where/backend/location/Location.java
+++ b/src/main/java/kr/where/backend/location/Location.java
@@ -68,7 +68,8 @@ public class Location {
 	public String getLocation() {
 		if (!this.member.isAgree()) {
 			return this.imacLocation;
-		} else {
+		}
+		if (member.isInCluster()) {
 			if (customLocation == null && imacLocation == null) {
 				return null;
 			} else if (customLocation == null) {
@@ -83,6 +84,7 @@ public class Location {
 				}
 			}
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/kr/where/backend/location/Location.java
+++ b/src/main/java/kr/where/backend/location/Location.java
@@ -87,4 +87,11 @@ public class Location {
 		return null;
 	}
 
+	public String getImacLocationIfInCluster() {
+		if (member.isInCluster()) {
+			return imacLocation;
+		}
+		return null;
+	}
+
 }

--- a/src/main/java/kr/where/backend/location/LocationRepository.java
+++ b/src/main/java/kr/where/backend/location/LocationRepository.java
@@ -6,13 +6,15 @@ import kr.where.backend.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
 	Location findByMember(Member member);
 
-	List<Location> findByImacLocationStartingWith(String prefix);
+	@Query("SELECT l FROM Location l WHERE l.imacLocation LIKE :prefix% AND l.member.inCluster = true")
+	List<Location> findByImacLocationStartingWithAndMemberIsInCluster(@Param("prefix") String prefix);
 
 	@Modifying
 	@Query("UPDATE Location location SET location.imacLocation = null")

--- a/src/main/java/kr/where/backend/location/LocationRepository.java
+++ b/src/main/java/kr/where/backend/location/LocationRepository.java
@@ -6,15 +6,13 @@ import kr.where.backend.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
 	Location findByMember(Member member);
 
-	@Query("SELECT l FROM Location l WHERE l.imacLocation LIKE :prefix% AND l.member.inCluster = true")
-	List<Location> findByImacLocationStartingWithAndMemberIsInCluster(@Param("prefix") String prefix);
+	List<Location> findByImacLocationStartingWithAndMemberInClusterTrue(String prefix);
 
 	@Modifying
 	@Query("UPDATE Location location SET location.imacLocation = null")

--- a/src/main/java/kr/where/backend/location/LocationService.java
+++ b/src/main/java/kr/where/backend/location/LocationService.java
@@ -88,7 +88,7 @@ public class LocationService {
 	 */
 	public ResponseLoggedImacListDTO getLoggedInIMacs(final AuthUser authUser, final String cluster) {
 		locationUtils.validateCluster(cluster);
-		final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberIsInCluster(cluster);
+		final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberInClusterTrue(cluster);
 
 		final List<Member> friends = groupMemberRepository.findMembersByGroupId(authUser.getDefaultGroupId());
 

--- a/src/main/java/kr/where/backend/location/LocationService.java
+++ b/src/main/java/kr/where/backend/location/LocationService.java
@@ -88,7 +88,7 @@ public class LocationService {
 	 */
 	public ResponseLoggedImacListDTO getLoggedInIMacs(final AuthUser authUser, final String cluster) {
 		locationUtils.validateCluster(cluster);
-		final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWith(cluster);
+		final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberIsInCluster(cluster);
 
 		final List<Member> friends = groupMemberRepository.findMembersByGroupId(authUser.getDefaultGroupId());
 
@@ -101,7 +101,7 @@ public class LocationService {
 									member.getIntraId(),
 									member.getIntraName(),
 									member.getImage(),
-									location.getImacLocationIfInCluster(),
+									location.getImacLocation(),
 									friends.contains(member)
 							);
 						})

--- a/src/main/java/kr/where/backend/location/LocationService.java
+++ b/src/main/java/kr/where/backend/location/LocationService.java
@@ -96,11 +96,16 @@ public class LocationService {
 				loggedInImacs.stream()
 						.map(location -> {
 							final Member member = location.getMember(); // 한 번만 가져오기
+							String imacLocation = location.getImacLocation();
+
+							if (!member.isInCluster()) {
+								imacLocation = null;
+							}
 							return ResponseLoggedImacDTO.of(
 									member.getIntraId(),
 									member.getIntraName(),
 									member.getImage(),
-									location.getImacLocation(),
+									imacLocation,
 									friends.contains(member)
 							);
 						})

--- a/src/main/java/kr/where/backend/location/LocationService.java
+++ b/src/main/java/kr/where/backend/location/LocationService.java
@@ -96,16 +96,12 @@ public class LocationService {
 				loggedInImacs.stream()
 						.map(location -> {
 							final Member member = location.getMember(); // 한 번만 가져오기
-							String imacLocation = location.getImacLocation();
 
-							if (!member.isInCluster()) {
-								imacLocation = null;
-							}
 							return ResponseLoggedImacDTO.of(
 									member.getIntraId(),
 									member.getIntraName(),
 									member.getImage(),
-									imacLocation,
+									location.getImacLocationIfInCluster(),
 									friends.contains(member)
 							);
 						})

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -119,9 +119,6 @@ public class Member {
 	public void setInCluster(final Hane hane) {
 		this.inCluster = Objects.equals(hane.getInoutState(), "IN");
 		this.inClusterUpdatedAt = LocalDateTime.now();
-
-//		if (!this.inCluster)
-//			this.location.initLocation();
 	}
 
 	public boolean isPossibleToUpdateInCluster() {

--- a/src/main/java/kr/where/backend/member/Member.java
+++ b/src/main/java/kr/where/backend/member/Member.java
@@ -120,8 +120,8 @@ public class Member {
 		this.inCluster = Objects.equals(hane.getInoutState(), "IN");
 		this.inClusterUpdatedAt = LocalDateTime.now();
 
-		if (!this.inCluster)
-			this.location.initLocation();
+//		if (!this.inCluster)
+//			this.location.initLocation();
 	}
 
 	public boolean isPossibleToUpdateInCluster() {

--- a/src/test/java/kr/where/backend/location/LocationServiceTest.java
+++ b/src/test/java/kr/where/backend/location/LocationServiceTest.java
@@ -1,5 +1,6 @@
 package kr.where.backend.location;
 
+import java.util.Objects;
 import kr.where.backend.api.json.CadetPrivacy;
 import kr.where.backend.api.json.hane.Hane;
 import kr.where.backend.auth.authUser.AuthUser;
@@ -10,7 +11,6 @@ import kr.where.backend.location.dto.UpdateCustomLocationDTO;
 import kr.where.backend.member.Member;
 import kr.where.backend.member.MemberRepository;
 import kr.where.backend.member.MemberService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.Assert.assertEquals;
 
 
 @SpringBootTest
@@ -81,7 +80,7 @@ public class LocationServiceTest {
     public void delete_custom_location_test() {
         //given
         authUser = new AuthUser(12345, "suhwpark", 1L);
-        memberCreateAndSave(12345, "suhwpark", "c1r1s1", "IN", authUser);
+        agreeMemberCreateAndSave(12345, "suhwpark", "c1r1s1", "IN", authUser);
 
         UpdateCustomLocationDTO updateCustomLocationDto = UpdateCustomLocationDTO.createForTest("1F open lounge");
         ResponseLocationDTO beforeResponseLocationDTO = locationService.updateCustomLocation(updateCustomLocationDto, authUser);
@@ -100,52 +99,85 @@ public class LocationServiceTest {
     void testLoggedInIMacCount() {
         //given
         AuthUser authUser1 = new AuthUser(123456, "suhwpark", 2L);
-        memberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
+        agreeMemberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
         AuthUser authUser2 = new AuthUser(222222, "jonhan", 2L);
-        memberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
 
         // when
         final ResponseLoggedImacListDTO responseLoggedImacListDTO = locationService.getLoggedInIMacs(authUser1, "c1");
 
         //then
-        assertEquals(2, responseLoggedImacListDTO.getMembers().size());
+        assertThat(1).isEqualTo(responseLoggedImacListDTO.getMembers().size());
     }
 
-    @DisplayName("imac에 로그인된 멤버 이름을 확인하는 테스트")
+    @DisplayName("imac에 로그인된 멤버를 조회하는 테스트")
     @Test
     @Rollback
-    void testLoggedInIMacMemberNames() {
+    void testLoggedInIMacMember() {
         // given
         AuthUser authUser1 = new AuthUser(123456, "suhwpark", 2L);
-        memberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
-        AuthUser authUser2 = new AuthUser(222222, "jonhan", 2L);
-        memberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
+        agreeMemberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
 
         // when
         final ResponseLoggedImacListDTO responseLoggedImacListDTO = locationService.getLoggedInIMacs(authUser1, "c1");
 
         //then
-        ResponseLoggedImacDTO responseLoggedImacDTO_1 = responseLoggedImacListDTO.getMembers().stream()
-                .filter(responseLoggedImacDTO -> "suhwpark".equals(responseLoggedImacDTO.getIntraName()))
+        final ResponseLoggedImacDTO responseLoggedImacDTO_1 = responseLoggedImacListDTO.getMembers().stream()
+                .filter(responseLoggedImacDTO -> Objects.equals("suhwpark", responseLoggedImacDTO.getIntraName()))
                 .findFirst()
                 .orElse(null);
-        Assertions.assertNotNull(responseLoggedImacDTO_1, "suhwpark is not found");
-        assertEquals("suhwpark", responseLoggedImacDTO_1.getIntraName());
+        assertThat(responseLoggedImacDTO_1).isNotNull();
+        assertThat("suhwpark").isEqualTo(responseLoggedImacDTO_1.getIntraName());
+    }
 
-        ResponseLoggedImacDTO responseLoggedImacDTO_2 = responseLoggedImacListDTO.getMembers().stream()
-                .filter(responseLoggedImacDTO -> "jonhan".equals(responseLoggedImacDTO.getIntraName()))
+    @DisplayName("imac에 로그인된 사람들 중 클러스터에 있는 사람만 조회하는 테스트")
+    @Test
+    @Rollback
+    void testLoggedInIMacMemberWithoutCluster() {
+        // given
+        final AuthUser authUser1 = new AuthUser(123456, "suhwpark", 2L);
+        agreeMemberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
+        final AuthUser authUser2 = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
+
+        // when
+        final ResponseLoggedImacListDTO responseLoggedImacListDTO = locationService.getLoggedInIMacs(authUser1, "c1");
+
+        //then
+        final ResponseLoggedImacDTO responseLoggedImacDTO_1 = responseLoggedImacListDTO.getMembers().stream()
+                .filter(responseLoggedImacDTO -> Objects.equals("suhwpark", responseLoggedImacDTO.getIntraName()))
+                .findFirst()
+                .orElse(null);
+        assertThat(responseLoggedImacDTO_1).isNotNull();
+        assertThat("suhwpark").isEqualTo(responseLoggedImacDTO_1.getIntraName());
+
+        final ResponseLoggedImacDTO responseLoggedImacDTO_2 = responseLoggedImacListDTO.getMembers().stream()
+                .filter(responseLoggedImacDTO -> Objects.equals("jonhan", responseLoggedImacDTO.getIntraName()))
                 .findFirst()
                 .orElse(null);
         Assertions.assertNotNull(responseLoggedImacDTO_2, "jonhan is not found");
         assertEquals("jonhan", responseLoggedImacDTO_2.getIntraName());
+        assertThat(responseLoggedImacDTO_2).isNull();
+    }
     }
 
     //멤버를 생성,저장하는 공통 메소드
     private void memberCreateAndSave(int intraId, String intraName, String location, String haneInOut, AuthUser authUser) {
+
+    //동의 멤버를 생성,저장하는 공통 메소드
+    private void agreeMemberCreateAndSave(int intraId, String intraName, String location, String haneInOut, AuthUser authUser) {
         Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
         SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
         CadetPrivacy cadetPrivacy = new CadetPrivacy(intraId, intraName, location, "image", true, "2022-10-31", CAMPUS_ID);
         Hane hane = Hane.create(haneInOut);
         Member member = memberService.createAgreeMember(cadetPrivacy, hane);
+    }
+
+    //비동의 멤버를 생성,저장하는 공통 메소드
+    private void disagreeMemberCreateAndSave(int intraId, String intraName, String location, String haneInOut, AuthUser authUser) {
+        Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("user"));
+        SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(authUser, "", authorities));
+        CadetPrivacy cadetPrivacy = new CadetPrivacy(intraId, intraName, location, "image", true, "2022-10-31", CAMPUS_ID);
+        Member member = memberService.createDisagreeMember(cadetPrivacy);
     }
 }

--- a/src/test/java/kr/where/backend/location/LocationServiceTest.java
+++ b/src/test/java/kr/where/backend/location/LocationServiceTest.java
@@ -155,9 +155,24 @@ public class LocationServiceTest {
                 .filter(responseLoggedImacDTO -> Objects.equals("jonhan", responseLoggedImacDTO.getIntraName()))
                 .findFirst()
                 .orElse(null);
-        Assertions.assertNotNull(responseLoggedImacDTO_2, "jonhan is not found");
-        assertEquals("jonhan", responseLoggedImacDTO_2.getIntraName());
         assertThat(responseLoggedImacDTO_2).isNull();
+    }
+
+    @DisplayName("imac에 로그인된 멤버 수를 조회하는 테스트")
+    @Test
+    @Rollback
+    void testLoggedInIMacMemberCount() {
+        // given
+        final AuthUser authUser1 = new AuthUser(123456, "suhwpark", 2L);
+        agreeMemberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
+        final AuthUser authUser2 = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
+
+        // when
+        List<Location> loggedImacs = locationRepository.findAll();
+
+        //then
+        assertThat(loggedImacs.size()).isEqualTo(2);
     }
     }
 

--- a/src/test/java/kr/where/backend/location/LocationServiceTest.java
+++ b/src/test/java/kr/where/backend/location/LocationServiceTest.java
@@ -174,10 +174,67 @@ public class LocationServiceTest {
         //then
         assertThat(loggedImacs.size()).isEqualTo(2);
     }
+
+    @DisplayName("Imac에 로그인되어 있어도 클러스터 내에 없으면 imac위치반환값이 null이 되어야 하는 테스트")
+    @Test
+    @Rollback
+    void getImacLocationNull() {
+        // given
+        final AuthUser authUser = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser);
+
+        // when
+        Member member = memberRepository.findByIntraId(222222).get();
+
+        //then
+        assertThat(member.getLocation().getLocation()).isNull();
     }
 
-    //멤버를 생성,저장하는 공통 메소드
-    private void memberCreateAndSave(int intraId, String intraName, String location, String haneInOut, AuthUser authUser) {
+    @DisplayName("Imac에 로그인되어 있고 클러스터 내에 있으면 imacLocation 반환해야 하는 테스트")
+    @Test
+    @Rollback
+    void getImacLocation() {
+        // given
+        final AuthUser authUser = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "IN", authUser);
+
+        // when
+        Member member = memberRepository.findByIntraId(222222).get();
+
+        //then
+        assertThat(member.getLocation().getLocation()).isEqualTo("c1r1s2");
+    }
+
+    @DisplayName("동의되지 않은 멤버 위치조회시 imacLocation 반환해야 하는 테스트")
+    @Test
+    @Rollback
+    void getImacLocationWithDisagreeMember() {
+        // given
+        final AuthUser authUser = new AuthUser(222222, "jonhan", 2L);
+        disagreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser);
+
+        // when
+        Member member = memberRepository.findByIntraId(222222).get();
+
+        //then
+        assertThat(member.getLocation().getLocation()).isEqualTo("c1r1s2");
+    }
+
+    @DisplayName("custom위치와 Imac위치 중 가장 최근것을 반환해야하는 테스트")
+    @Test
+    @Rollback
+    void getImacLocationf() {
+        // given
+        final AuthUser authUser = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "IN", authUser);
+
+        // when
+        Member member = memberRepository.findByIntraId(222222).get();
+        member.getLocation().setCustomLocation("1층 회의실");
+
+        //then
+        assertThat(member.getLocation().getLocation()).isEqualTo("1층 회의실");
+    }
 
     //동의 멤버를 생성,저장하는 공통 메소드
     private void agreeMemberCreateAndSave(int intraId, String intraName, String location, String haneInOut, AuthUser authUser) {

--- a/src/test/java/kr/where/backend/member/memberServiceTest.java
+++ b/src/test/java/kr/where/backend/member/memberServiceTest.java
@@ -240,7 +240,7 @@ public class memberServiceTest {
 	public void findOneByIntraId() {
 		//given
 		CadetPrivacy cadetPrivacy = new CadetPrivacy(135436, "suhwpark", "", "image", true, "2022-10-31", CAMPUS_ID);
-		Hane hane = Hane.create("OUT");
+		Hane hane = Hane.create("IN");
 		Member createMember = memberService.createAgreeMember(cadetPrivacy, hane);
 
 		//when


### PR DESCRIPTION
# 문제
유저가 아이맥에 로그인중인 상태로 외출을 하고 오면 현재자리가 null로 세팅되어 버린다.
## 현재 로직
- 현재 hane가 OUT되면 imac자리가 login중임에도 imacLocation을 null로 세팅한다. 그래서 외출 후 imac자리가 null로 떠 버리는 것이다.
## 해결 방법
- hane가 out이더라도 imacLocation을 null 초기화하지 않는다. 즉 imacLocation은 실제 imac이 로그아웃 되었을때만 null로 바뀌게 된다.
- imacLocation을 조회할때 hane가 out일땐 null을 반환하고, in일때 imacLocation을 반환한다. 

# 2025.01.31 변경사항
에러 발생하여 위에서 결정한 해결방법을 변경하였습니다.
아래 코드에서 ResponseLoggedImacDTO.of 할때 location값에 null이 들어가면 에러가 터지게 되는 상황입니다.
### LocationService.java
```	
public ResponseLoggedImacListDTO getLoggedInIMacs(final AuthUser authUser, final String cluster) {
		locationUtils.validateCluster(cluster);
		final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberIsInCluster(cluster);

		final List<Member> friends = groupMemberRepository.findMembersByGroupId(authUser.getDefaultGroupId());

		return ResponseLoggedImacListDTO.of(
				loggedInImacs.stream()
						.map(location -> {
							final Member member = location.getMember();

							return ResponseLoggedImacDTO.of(
									member.getIntraId(),
									member.getIntraName(),
									member.getImage(),
									location.getImacLocation(),
									friends.contains(member)
							);
						})
						.toList()
		);
	}
```

## 변경된 해결방법
기존 : location 레포지토리에서 c1(1클러스터조회를 가정)로 시작하는 location을 찾아왔었습니다. 사실 애초에 클러스터내에 있지 않은 imacLocation은 DB에서 조회해올 필요가 없어보입니다.
변경 : 그래서 location 레포지토리에서 c1으로 시작하면서 `member.inCluster == true`인 것만 조회하게 변경하였습니다.

	