### PR TITLE
imac자리 표시할때 hane 정보수집 동의안한 사람은 자리 표시가 안되는 문제를 수정하였습니다.

### DIFF
--- a/src/main/java/kr/where/backend/location/LocationRepository.java
+++ b/src/main/java/kr/where/backend/location/LocationRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 public interface LocationRepository extends JpaRepository<Location, Long> {
 	Location findByMember(Member member);
 
-	List<Location> findByImacLocationStartingWithAndMemberInClusterTrue(String prefix);
+	List<Location> findByImacLocationStartingWithAndMemberInClusterTrueOrMemberAgreeFalse(String prefix);
 
 	Integer countAllByImacLocationStartingWith(String prefix);
 

--- a/src/main/java/kr/where/backend/location/LocationRepository.java
+++ b/src/main/java/kr/where/backend/location/LocationRepository.java
@@ -6,13 +6,17 @@ import kr.where.backend.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
 	Location findByMember(Member member);
 
-	List<Location> findByImacLocationStartingWithAndMemberInClusterTrueOrMemberAgreeFalse(String prefix);
+	@Query("SELECT l FROM Location l "
+			+ "WHERE l.imacLocation LIKE :prefix% "
+			+ "AND (l.member.inCluster = TRUE OR l.member.agree = FALSE)")
+	List<Location> getFilteredLocations(@Param("prefix") String prefix);
 
 	Integer countAllByImacLocationStartingWith(String prefix);
 

--- a/src/main/java/kr/where/backend/location/LocationService.java
+++ b/src/main/java/kr/where/backend/location/LocationService.java
@@ -87,7 +87,7 @@ public class LocationService {
      */
     public ResponseLoggedImacListDTO getLoggedInIMacs(final AuthUser authUser, final String cluster) {
         locationUtils.validateCluster(cluster);
-        final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberInClusterTrueOrMemberAgreeFalse(cluster);
+        final List<Location> loggedInImacs = locationRepository.getFilteredLocations(cluster);
 
         final List<Member> friends = groupMemberRepository.findMembersByGroupId(authUser.getDefaultGroupId());
 

--- a/src/main/java/kr/where/backend/location/LocationService.java
+++ b/src/main/java/kr/where/backend/location/LocationService.java
@@ -87,7 +87,7 @@ public class LocationService {
      */
     public ResponseLoggedImacListDTO getLoggedInIMacs(final AuthUser authUser, final String cluster) {
         locationUtils.validateCluster(cluster);
-        final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberInClusterTrue(cluster);
+        final List<Location> loggedInImacs = locationRepository.findByImacLocationStartingWithAndMemberInClusterTrueOrMemberAgreeFalse(cluster);
 
         final List<Member> friends = groupMemberRepository.findMembersByGroupId(authUser.getDefaultGroupId());
 

--- a/src/test/java/kr/where/backend/location/LocationServiceTest.java
+++ b/src/test/java/kr/where/backend/location/LocationServiceTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.*;
-import static org.junit.Assert.assertEquals;
 
 @SpringBootTest
 @Transactional
@@ -153,6 +152,31 @@ public class LocationServiceTest {
                 .findFirst()
                 .orElse(null);
         assertThat(responseLoggedImacDTO_2).isNull();
+    }
+
+    @DisplayName("imac에 로그인된 멤버를 조회하는데 동의안된 멤버도 가져와야 하는 테스트")
+    @Test
+    @Rollback
+    void testLoggedInIMacCountForDisagreeMember() {
+        //given
+        AuthUser authUser1 = new AuthUser(123456, "suhwpark", 2L);
+        agreeMemberCreateAndSave(123456, "suhwpark", "c1r1s1", "IN", authUser1);
+        AuthUser authUser2 = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
+        AuthUser authUser3 = new AuthUser(333333, "soohlee", 2L);
+        disagreeMemberCreateAndSave(333333, "soohlee", "c1r1s3", "OUT", authUser3);
+
+        // when
+        final ResponseLoggedImacListDTO responseLoggedImacListDTO = locationService.getLoggedInIMacs(authUser1, "c1");
+        ResponseLoggedImacDTO disAgreeMember = responseLoggedImacListDTO.getMembers().stream().
+                filter(member -> Objects.equals("soohlee", member.getIntraName())).
+                findFirst().
+                orElse(null);
+
+        //then
+        assertThat(responseLoggedImacListDTO.getMembers().size()).isEqualTo(2);
+        assertThat(disAgreeMember.getIntraName()).isEqualTo("soohlee");
+
     }
 
     @DisplayName("imac에 로그인된 멤버 수를 조회하는 테스트")

--- a/src/test/java/kr/where/backend/location/LocationServiceTest.java
+++ b/src/test/java/kr/where/backend/location/LocationServiceTest.java
@@ -179,6 +179,31 @@ public class LocationServiceTest {
 
     }
 
+    @DisplayName("imac에 로그인된 멤버를 조회하는데 location이 null인 멤버는 안가져와야 하는 테스트")
+    @Test
+    @Rollback
+    void testLoggedInIMacCountForNull() {
+        //given
+        AuthUser authUser1 = new AuthUser(123456, "suhwpark", 2L);
+        agreeMemberCreateAndSave(123456, "suhwpark", null, "IN", authUser1);
+        AuthUser authUser2 = new AuthUser(222222, "jonhan", 2L);
+        agreeMemberCreateAndSave(222222, "jonhan", "c1r1s2", "OUT", authUser2);
+        AuthUser authUser3 = new AuthUser(333333, "soohlee", 2L);
+        disagreeMemberCreateAndSave(333333, "soohlee", "c1r1s3", "OUT", authUser3);
+
+        // when
+        final ResponseLoggedImacListDTO responseLoggedImacListDTO = locationService.getLoggedInIMacs(authUser1, "c1");
+        ResponseLoggedImacDTO disAgreeMember = responseLoggedImacListDTO.getMembers().stream().
+                filter(member -> Objects.equals("soohlee", member.getIntraName())).
+                findFirst().
+                orElse(null);
+
+        //then
+        assertThat(responseLoggedImacListDTO.getMembers().size()).isEqualTo(1);
+        assertThat(disAgreeMember.getIntraName()).isEqualTo("soohlee");
+
+    }
+
     @DisplayName("imac에 로그인된 멤버 수를 조회하는 테스트")
     @Test
     @Rollback


### PR DESCRIPTION
# imac자리 표시할때 hane 정보수집 동의안한 사람은 자리 표시가 안되는 문제를 수정하였습니다.
### 이전 로직
inCluster가 true인 유저만 가져와서 표시한다. 
### 이로 인한 문제
그런데 hane동의안된 유저는 InCluster가 업데이트가 안되기 때문에 자리를 가져오지 않게된다.

# 해결 로직
imac 로그인자리 조회할때 hane정보수집 동의안한 유저도 같이 조회한다.