### PR TITLE
announcement API 리팩토링했습니다.

### DIFF
--- a/src/main/java/kr/where/backend/announcement/AnnouncementController.java
+++ b/src/main/java/kr/where/backend/announcement/AnnouncementController.java
@@ -1,6 +1,7 @@
 package kr.where.backend.announcement;
 
 import jakarta.validation.Valid;
+import kr.where.backend.announcement.dto.RequestPaginationDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementListDTO;
 import kr.where.backend.announcement.dto.CreateAnnouncementDTO;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,14 +46,11 @@ public class AnnouncementController implements AnnouncementApiDocs {
     /**
      * 공지 페이지 단위로 조회
      *
-     * @param page 쿼리 파라미터로 전달받은 페이지 번호
      * @return ResponseEntity(ResponseAnnouncementListDTO)
      */
     @GetMapping()
-    public ResponseEntity<ResponseAnnouncementListDTO> getAnnouncement(
-            @RequestParam(value = "page", required = false) final Integer page,
-            @RequestParam(value = "size", required = false) final Integer size) {
-        return ResponseEntity.status(HttpStatus.OK).body(announcementService.getAnnouncementPage(page, size));
+    public ResponseEntity<ResponseAnnouncementListDTO> getAnnouncement(@Valid @ModelAttribute RequestPaginationDTO requestPaginationDTO) {
+        return ResponseEntity.status(HttpStatus.OK).body(announcementService.getAnnouncementPage(requestPaginationDTO));
     }
 
     /**

--- a/src/main/java/kr/where/backend/announcement/AnnouncementRepository.java
+++ b/src/main/java/kr/where/backend/announcement/AnnouncementRepository.java
@@ -8,5 +8,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
     Optional<Announcement> findById(Long id);
-    List<Announcement> findAllByOrderByCreateAtDesc();
 }

--- a/src/main/java/kr/where/backend/announcement/AnnouncementService.java
+++ b/src/main/java/kr/where/backend/announcement/AnnouncementService.java
@@ -2,6 +2,7 @@ package kr.where.backend.announcement;
 
 import java.util.List;
 import kr.where.backend.announcement.dto.CreateAnnouncementDTO;
+import kr.where.backend.announcement.dto.RequestPaginationDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementListDTO;
 import kr.where.backend.announcement.exception.AnnouncementException;
@@ -35,23 +36,12 @@ public class AnnouncementService {
         announcementRepository.delete(announcement);
     }
 
-    public ResponseAnnouncementListDTO getAnnouncementPage(final Integer pageNumber, final Integer size) {
-        Page<Announcement> announcements;
-        if (pageNumber == null || size == null)
-            throw new AnnouncementException.InvalidArgumentException();
-
-        try {
-            announcements = announcementRepository.findAll(
-                    PageRequest.of(pageNumber, size, Sort.by(Direction.DESC, CREATE_AT)));
-        } catch (IllegalArgumentException e) {
-            throw new AnnouncementException.InvalidArgumentException();
-        }
-
-        final int totalPages = announcements.getTotalPages();
-        final long totalElements = announcements.getTotalElements();
+    public ResponseAnnouncementListDTO getAnnouncementPage(final RequestPaginationDTO requestPaginationDTO) {
+        final Page<Announcement> announcements = announcementRepository.findAll(
+                PageRequest.of(requestPaginationDTO.getPage(), requestPaginationDTO.getSize(), Sort.by(Direction.DESC, CREATE_AT)));
 
         final List<ResponseAnnouncementDTO> responseAnnouncementDTO = announcements.stream().map(
                 ResponseAnnouncementDTO::of).toList();
-        return ResponseAnnouncementListDTO.of(responseAnnouncementDTO, totalPages, totalElements);
+        return ResponseAnnouncementListDTO.of(responseAnnouncementDTO, announcements.getTotalPages(), announcements.getTotalElements());
     }
 }

--- a/src/main/java/kr/where/backend/announcement/dto/RequestPaginationDTO.java
+++ b/src/main/java/kr/where/backend/announcement/dto/RequestPaginationDTO.java
@@ -1,0 +1,22 @@
+package kr.where.backend.announcement.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class RequestPaginationDTO {
+    @NotNull
+    @Min(value = 0)
+    private Integer page;
+    @NotNull
+    @Min(value = 1)
+    private Integer size;
+}

--- a/src/main/java/kr/where/backend/announcement/swagger/AnnouncementApiDocs.java
+++ b/src/main/java/kr/where/backend/announcement/swagger/AnnouncementApiDocs.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import kr.where.backend.announcement.dto.CreateAnnouncementDTO;
+import kr.where.backend.announcement.dto.RequestPaginationDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementListDTO;
 import kr.where.backend.auth.authUser.AuthUser;
@@ -16,6 +17,7 @@ import kr.where.backend.auth.authUser.AuthUserInfo;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,9 +56,7 @@ public interface AnnouncementApiDocs {
             }
     )
     @GetMapping(value = "", params = ("page"))
-    ResponseEntity<ResponseAnnouncementListDTO> getAnnouncement(
-            @RequestParam("page") final Integer page,
-            @RequestParam("size") final Integer size);
+    ResponseEntity<ResponseAnnouncementListDTO> getAnnouncement(@Valid @ModelAttribute RequestPaginationDTO requestPaginationDTO);
 
     @Operation(summary = "Delete announcement API", description = "공지 삭제",
             parameters = {

--- a/src/test/java/kr/where/backend/announcement/AnnouncementServiceTest.java
+++ b/src/test/java/kr/where/backend/announcement/AnnouncementServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
+import kr.where.backend.announcement.dto.RequestPaginationDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementDTO;
 import kr.where.backend.announcement.dto.ResponseAnnouncementListDTO;
 import java.util.Collection;
@@ -116,7 +117,8 @@ public class AnnouncementServiceTest {
         announcementRepository.save(announcementSix);
 
         //when
-        ResponseAnnouncementListDTO responseAnnouncementListDto = announcementService.getAnnouncementPage(0, 5);
+        RequestPaginationDTO requestPaginationDTO = new RequestPaginationDTO(0, 5);
+        ResponseAnnouncementListDTO responseAnnouncementListDto = announcementService.getAnnouncementPage(requestPaginationDTO);
         List<ResponseAnnouncementDTO> ResponseAnnouncementDTO = responseAnnouncementListDto.getAnnouncements();
         //then
         assertEquals(5, ResponseAnnouncementDTO.size());
@@ -127,7 +129,8 @@ public class AnnouncementServiceTest {
         assertEquals(announcementTwo.getId(), ResponseAnnouncementDTO.get(4).getAnnouncementId());
 
         //when
-        ResponseAnnouncementListDTO responseAnnouncementListDTO2 = announcementService.getAnnouncementPage(1, 5);
+        requestPaginationDTO = new RequestPaginationDTO(1, 5);
+        ResponseAnnouncementListDTO responseAnnouncementListDTO2 = announcementService.getAnnouncementPage(requestPaginationDTO);
         List<ResponseAnnouncementDTO> responseAnnouncementDtos2 = responseAnnouncementListDTO2.getAnnouncements();
         //then
         assertEquals(1, responseAnnouncementDtos2.size());
@@ -139,7 +142,8 @@ public class AnnouncementServiceTest {
     @Rollback
     public void getAnnouncementPageWhenEmptyTest() {
         //when
-        ResponseAnnouncementListDTO responseAnnouncementListDto = announcementService.getAnnouncementPage(0, 5);
+        RequestPaginationDTO requestPaginationDTO = new RequestPaginationDTO(0, 5);
+        ResponseAnnouncementListDTO responseAnnouncementListDto = announcementService.getAnnouncementPage(requestPaginationDTO);
         List<ResponseAnnouncementDTO> responseAnnouncementDTO = responseAnnouncementListDto.getAnnouncements();
         //then
         assertTrue(responseAnnouncementDTO.isEmpty());


### PR DESCRIPTION
페이지네이션 인자를 파라미터 2개로 받고 있습니다. 이것을 DTO로 감싸서 받을 수 있게 하였습니다.

변경 후 개선점 : 
1. 파라미터가 추가되면 그만큼 컨트롤러 메소드의 인자수가 늘어나게 되어 코드가 길어지게 되어 복잡해지게 되고, 파라미터개수 변경시마다 서비스 코드도 수정해야 해 코드 변경점이 많았습니다. 이는 DTO가 파라미터들을 모두 포함하게 하여 해결되었습니다.
2. DTO를 사용하게 되어 파리미터의 검증에 `@Valid` 어노테이션을 사용할 수 있게 되었습니다. 덕분에 코드가 줄어들고 가독성이 개선되었습니다.
